### PR TITLE
Add Authorization Roles provider

### DIFF
--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthRolesProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthRolesProvider.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.authz;
+
+import static java.lang.String.format;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.User;
+import org.dataconservancy.pass.model.User.Role;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides the authorization roles for a user
+ * <p>
+ * Returns their PASS User resource ID as their user role, and institution-scoped submitter/admin roles as defined in
+ * their corresponding User object.
+ * </p>
+ * <p>
+ * Uses an expiring LRU cache to cache the roles for a brief period of time.
+ * </p>
+ *
+ * @author apb@jhu.edu
+ */
+public class AuthRolesProvider {
+
+    static final Logger LOG = LoggerFactory.getLogger(AuthRolesProvider.class);
+
+    final String ROLE_BASE = "http://dataconservancy.org/ns/pass/roles#";
+
+    private final PassClient client;
+
+    private final ExpiringLRUCache<URI, User> cache;
+
+    public AuthRolesProvider(PassClient passClient) {
+        this.client = passClient;
+        this.cache = new ExpiringLRUCache<>(100, Duration.ofMinutes(30));
+    }
+
+    public AuthRolesProvider(PassClient passClient, ExpiringLRUCache<URI, User> cache) {
+        this.client = passClient;
+        this.cache = cache;
+    }
+
+    /**
+     * Get all applicable authorization roles for a user.
+     *
+     * @param authUser The authenticated user.
+     * @return All roles
+     */
+    public Set<URI> getRoles(AuthUser authUser) {
+        final Set<URI> roles = new HashSet<>();
+
+        if (authUser == null) {
+            LOG.warn("Authenticated user is null (this should never happen)");
+            return roles;
+        }
+
+        if (authUser.getId() == null) {
+            LOG.info("Authenticated user {} does not have a PASS User resource yet", authUser.getPrincipal());
+            return roles;
+        }
+
+        final User user;
+        try {
+            user = cache.getOrDo(authUser.getId(),
+                    () -> client.readResource(authUser.getId(), User.class));
+        } catch (final Exception e) {
+            throw new RuntimeException("Error reading User resource for" + authUser.getId(), e);
+        }
+
+        // Should never really happen
+        if (user == null) {
+            LOG.warn("User {} was not found, granting NO authz roles", authUser.getId());
+            return roles;
+        }
+
+        for (final String domain : authUser.getDomains()) {
+            for (final Role role : user.getRoles()) {
+                roles.add(URI.create(ROLE_BASE + format("%s@%s", role, domain)));
+            }
+        }
+
+        roles.add(user.getId());
+
+        return roles;
+    }
+}

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
@@ -17,6 +17,8 @@
 package org.dataconservancy.pass.authz;
 
 import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author apb@jhu.edu
@@ -28,6 +30,8 @@ public class AuthUser {
     private String institutionalId;
     private URI id;
     private boolean isFaculty;
+    private String principal;
+    private Set<String> domains = new HashSet<>();
 
     /**
      * boolean indicating whether a person has faculty status
@@ -108,5 +112,36 @@ public class AuthUser {
     public void setName(String name) {
         this.name = name;
     }
+    
+    /** 
+     * Get all domains in which the user has affiliation..
+     * <p>
+     * The domain qualifies the username (eppn, in shib), and scoped 
+     * affiliations.  Typically, it is the institution (e.g. jonhshopkins.edu)
+     * </p>
+     * @return Set of all domains, or empty if none;
+     */
+    public Set<String> getDomains() {
+        return domains;
+    }
+    
+    /** Get the user's principal, identifying them in their authorization domain.
+     * <p>
+     * In shib terms, this is eppn;
+     * </p>
+     * @return
+     */
+    public String getPrincipal() {
+        return principal;
+    }
+    
+    /** Set the user's principal.
+     * 
+     * @param principal
+     */
+    public void setPrincipal(String principal) {
+        this.principal = principal;
+    }
+   
 }
 

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ExpiringLRUCache.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ExpiringLRUCache.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.authz;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A cache that holds a fixed number of items, for a fixed time.
+ * <p>
+ * When cache reaches capacity, the oldest entries are evicted. All entries are evicted after a set duration. This is
+ * helpful for temporarily caching authorizations that may be expensive to look up.
+ * </p>
+ *
+ * @author apb@jhu.edu
+ */
+@SuppressWarnings("serial")
+public class ExpiringLRUCache<K, V> {
+
+    Logger LOG = LoggerFactory.getLogger(ExpiringLRUCache.class);
+
+    ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    ExecutorService runner = Executors.newCachedThreadPool();
+
+    final Duration expiry;
+
+    private final Map<K, Future<V>> cache;
+
+    /**
+     * Create a cache of the desired size expiration duration for entries.
+     *
+     * @param capacity Capacity of the cache;
+     * @param expiry How long each entry may live in the cache;
+     */
+    public ExpiringLRUCache(final int capacity, final Duration expiry) {
+        cache = new LinkedHashMap<K, Future<V>>(capacity) {
+
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, Future<V>> eldest) {
+
+                if (size() > capacity) {
+                    LOG.info("Cache full, removing oldest entry; {}", eldest.getKey());
+                    return true;
+                }
+                return false;
+            }
+        };
+
+        this.expiry = expiry;
+    }
+
+    /**
+     * Get a cached value, or run the provided generator to compute a new value.
+     *
+     * @param key Retrieval key
+     * @param generator Function that MAY be executed, if there is no cached value
+     * @return The cached or generated value.
+     */
+    public V getOrDo(K key, Callable<V> generator) {
+
+        final Future<V> result;
+        synchronized (cache) {
+
+            if (cache.containsKey(key)) {
+                result = cache.get(key);
+            } else {
+                result = runner.submit(generator);
+                cache.put(key, result);
+                scheduler.schedule(() -> {
+                    remove(key);
+                }, expiry.toMillis(), TimeUnit.MILLISECONDS);
+            }
+        }
+        return doGet(result);
+    }
+
+    private void remove(K key) {
+        synchronized (cache) {
+            cache.remove(key);
+        }
+    }
+
+    /**
+     * Get a cached value, or null if not present in cache.
+     *
+     * @param key Cache key.
+     * @return
+     */
+    public V get(K key) {
+        synchronized (cache) {
+            return Optional.ofNullable(cache.get(key)).map(ExpiringLRUCache::doGet).orElse(null);
+        }
+    }
+
+    private static <V> V doGet(Future<V> value) {
+        try {
+            return value.get();
+        } catch (final ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+}

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -17,11 +17,14 @@
 package org.dataconservancy.pass.authz;
 
 import org.dataconservancy.pass.client.PassClient;
-import org.dataconservancy.pass.client.PassClientFactory;
 import org.dataconservancy.pass.model.User;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
+
+import static java.util.Arrays.stream;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Implementation of the AuthUserProvider interface for JHU's Shibboleth service
@@ -43,9 +46,9 @@ public class ShibAuthUserProvider implements AuthUserProvider {
     static final String EMAIL_HEADER = "Mail";
     static final String EPPN_HEADER = "Eppn";
     static final String UNSCOPED_AFFILIATION_HEADER = "Unscoped-Affiliation";
+    static final String SCOPED_AFFILIATION_HEADER = "Affiliation";
     
     final PassClient passClient;
-    
     
     public ShibAuthUserProvider(PassClient client) {
         this.passClient = client;
@@ -87,6 +90,15 @@ public class ShibAuthUserProvider implements AuthUserProvider {
         user.setInstitutionalId(institutionalId.trim().toLowerCase());//this is our normal format
         user.setFaculty(isFaculty);
         user.setId(id);
+        user.setPrincipal(request.getHeader(EPPN_HEADER));
+        
+        
+        user.getDomains().add(request.getHeader(EPPN_HEADER).split("@")[1]);
+        user.getDomains().addAll(stream(ofNullable(
+                request.getHeader(SCOPED_AFFILIATION_HEADER)).orElse("").split(";"))
+                        .filter(sa -> sa.contains("@"))
+                        .map(sa -> sa.split("@")[1])
+                        .collect(toSet()));
 
         return user;
     }

--- a/pass-authz-core/src/test/java/org/dataconservancy/pass/authz/AuthRolesProviderTest.java
+++ b/pass-authz-core/src/test/java/org/dataconservancy/pass/authz/AuthRolesProviderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.authz;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.User;
+import org.dataconservancy.pass.model.User.Role;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AuthRolesProviderTest {
+
+    @Mock
+    PassClient client;
+
+    AuthRolesProvider toTest;
+
+    AuthUser authUser;
+
+    User user;
+
+    final String domain = "ruminant.edu";
+
+    @Before
+    public void setUp() {
+        user = new User();
+        user.setId(URI.create("test:" + UUID.randomUUID().toString()));
+        authUser = new AuthUser();
+        authUser.setPrincipal("gladys@ruminant.edu");
+        authUser.getDomains().add("ruminant.edu");
+        authUser.setId(user.getId());
+
+        when(client.readResource(eq(user.getId()), eq(User.class))).thenReturn(user);
+        toTest = new AuthRolesProvider(client);
+    }
+
+    // Somebody who doesn't have a User in PASS shouldn't have any roles.
+    @Test
+    public void noUserInPassTest() {
+        authUser.setId(null);
+
+        assertTrue(toTest.getRoles(authUser).isEmpty());
+    }
+
+    // Somebody that hasn't been assigned any PASS roles should have only their userID as a role.
+    @Test
+    public void noPassRolesTest() {
+        user.setRoles(emptyList());
+
+        final Set<URI> roles = toTest.getRoles(authUser);
+        assertEquals(1, roles.size());
+        assertTrue(roles.contains(user.getId()));
+    }
+
+    @Test
+    public void singleRoleTest() {
+        user.setRoles(asList(Role.SUBMITTER));
+
+        final Set<URI> roles = toTest.getRoles(authUser);
+        assertEquals(2, roles.size());
+    }
+
+    @Test
+    public void twoRolesTest() {
+        user.setRoles(asList(Role.SUBMITTER, Role.ADMIN));
+
+        final Set<URI> roles = toTest.getRoles(authUser);
+        assertEquals(3, roles.size());
+    }
+
+    // Make sure all submitters from the same institution share the same submitter role.
+    @Test
+    public void twoSubmittersSameRoleTest() {
+        final User user2 = new User();
+        user2.setId(URI.create("test:" + UUID.randomUUID().toString()));
+        final AuthUser authUser2 = new AuthUser();
+        authUser2.setPrincipal("clarabelle@ruminant.edu");
+        authUser2.getDomains().add("ruminant.edu");
+        authUser2.setId(user2.getId());
+
+        user.setRoles(asList(Role.SUBMITTER));
+        user2.setRoles(asList(Role.SUBMITTER));
+
+        when(client.readResource(eq(user2.getId()), eq(User.class))).thenReturn(user2);
+
+        final Set<URI> roles1 = toTest.getRoles(authUser);
+        final Set<URI> roles2 = toTest.getRoles(authUser2);
+
+        final Set<URI> commonRoles = new HashSet<>(roles1);
+        commonRoles.retainAll(roles2);
+
+        assertEquals(1, commonRoles.size());
+        assertEquals(2, roles1.size());
+        assertEquals(2, roles2.size());
+    }
+
+    // Make sure that submitters at different institutions have different submitter roles
+    @Test
+    public void twoSubmittersDifferentInstitutionsTest() {
+        final User user2 = new User();
+        user2.setId(URI.create("test:" + UUID.randomUUID().toString()));
+        final AuthUser authUser2 = new AuthUser();
+        authUser2.setPrincipal("clarabelle@ungulate.edu");
+        authUser2.getDomains().add("ungulate.edu");
+        authUser2.setId(user2.getId());
+
+        user.setRoles(asList(Role.SUBMITTER));
+        user2.setRoles(asList(Role.SUBMITTER));
+
+        when(client.readResource(eq(user2.getId()), eq(User.class))).thenReturn(user2);
+
+        final Set<URI> roles1 = toTest.getRoles(authUser);
+        final Set<URI> roles2 = toTest.getRoles(authUser2);
+
+        final Set<URI> commonRoles = new HashSet<>(roles1);
+        commonRoles.retainAll(roles2);
+
+        assertEquals(0, commonRoles.size());
+        assertEquals(2, roles1.size());
+        assertEquals(2, roles2.size());
+    }
+
+}

--- a/pass-authz-core/src/test/java/org/dataconservancy/pass/authz/ExpiringLRUCacheTest.java
+++ b/pass-authz-core/src/test/java/org/dataconservancy/pass/authz/ExpiringLRUCacheTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.authz;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class ExpiringLRUCacheTest {
+
+    final String KEY1 = "key1";
+
+    final String KEY2 = "key2";
+
+    final String KEY3 = "key3";
+
+    final String VALUE1 = "value1";
+
+    final String VALUE2 = "value2";
+
+    final String VALUE3 = "value3";
+
+    @Test
+    public void capacityTest() {
+        final ExpiringLRUCache<String, String> toTest = new ExpiringLRUCache<>(2, Duration.ofSeconds(1));
+
+        toTest.getOrDo(KEY1, () -> VALUE1);
+        toTest.getOrDo(KEY2, () -> VALUE2);
+
+        assertEquals(VALUE1, toTest.get(KEY1));
+        assertEquals(VALUE2, toTest.get(KEY2));
+
+        toTest.getOrDo(KEY3, () -> VALUE3);
+        assertEquals(VALUE2, toTest.get(KEY2));
+        assertEquals(VALUE3, toTest.get(KEY3));
+        assertNull(toTest.get(KEY1));
+    }
+
+    @Test
+    public void expiryTest() throws Exception {
+        final ExpiringLRUCache<String, String> toTest = new ExpiringLRUCache<>(50, Duration.ofMillis(1));
+
+        toTest.getOrDo(KEY1, () -> VALUE1);
+        toTest.getOrDo(KEY2, () -> VALUE2);
+
+        Thread.sleep(75);
+
+        assertNull(toTest.get(KEY1));
+        assertNull(toTest.get(KEY2));
+    }
+
+    @Test
+    public void generateOnlyWhenNecessaryTest() {
+        final ExpiringLRUCache<String, Integer> toTest = new ExpiringLRUCache<>(10, Duration.ofSeconds(1));
+
+        final AtomicInteger executionCount = new AtomicInteger(0);
+
+        assertEquals(1, toTest.getOrDo(KEY1, () -> executionCount.incrementAndGet()).intValue());
+        assertEquals(1, toTest.getOrDo(KEY1, () -> executionCount.incrementAndGet()).intValue());
+        assertEquals(1, toTest.getOrDo(KEY1, () -> executionCount.incrementAndGet()).intValue());
+
+        assertEquals(1, executionCount.get());
+
+    }
+}


### PR DESCRIPTION
* Adds additional principal/domain fields to `AuthUser` and `ShibAuthUserProvider`
* Adds an authorization roles provider based on `AuthUser` and the contents of `User`
* Adds a time-limited and capacity-limited LRU cache for caching `User` records for a period of time, so that it is not necessary to query the repository/index on every request.

Every `User` gets his/her PASS User ID (e.g. `http://pass/fcrepo/rest/users/a/b/c/abc123`) as a role (i.e. for assigning permissions for resources specifically to that user)

Additional roles are determined by `roles` on `User`, an are scoped by institution, such as `http://dataconservancy.org/ns/pass/roles#submitter@johnshopkins.edu`.