### PR TITLE
Replace example.org in context URL with oapass.org

### DIFF
--- a/pass-authz-core/pom.xml
+++ b/pass-authz-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-core</artifactId>
 

--- a/pass-authz-filters/pom.xml
+++ b/pass-authz-filters/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-filters</artifactId>
 

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -170,7 +170,7 @@
 
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.8-2.1-SNAPSHOT</name>
+              <name>oapass/indexer:0.0.10-2.2-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-integration</artifactId>
 
@@ -174,7 +174,7 @@
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>
-                  <PI_FEDORA_USER>fedoraAdmin</PI_FEDORA_USER>
+                  <PI_FEDORA_USER>admin</PI_FEDORA_USER>
                   <PI_FEDORA_PASS>moo</PI_FEDORA_PASS>
                   <PI_FEDORA_INTERNAL_BASE>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest/</PI_FEDORA_INTERNAL_BASE>
                   <PI_ES_BASE>http://elasticsearch:9200/</PI_ES_BASE>

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -181,7 +181,7 @@
                   <PI_ES_INDEX>http://elasticsearch:9200/pass/</PI_ES_INDEX>
                   <PI_FEDORA_JMS_BROKER>tcp://${FCREPO_HOST}:${FCREPO_JMS_PORT}</PI_FEDORA_JMS_BROKER>
                   <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
-                  <PI_TYPE_PREFIX>http://example.org/pass/</PI_TYPE_PREFIX>
+                  <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                   <PI_LOG_LEVEL>DEBUG</PI_LOG_LEVEL>
                 </env>
                 <links>

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
@@ -67,7 +67,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         }
 
         final PassClient passClient = PassClientFactory.getPassClient();
-        attempt(15, () -> {
+        attempt(20, () -> {
             Assert.assertNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER)));
         });
     }
@@ -84,9 +84,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         final PassClient passClient = PassClientFactory.getPassClient();
         URI id = passClient.createResource(newUser);
 
-        attempt(15, () -> {
-            Assert.assertNotNull(passClient.findByAttribute(User.class, "localKey", "10933511")); 
-        });
+        attempt(20, () -> Assert.assertNotNull(passClient.findByAttribute(User.class, "localKey", "10933511")));
 
         Map<String, String> shibHeaders = new HashMap<>();
         shibHeaders.put(SHIB_DISPLAYNAME_HEADER, "Bugs Bunny");
@@ -133,11 +131,9 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
             Assert.assertEquals(200, response.code());
         }
         
-        URI id = attempt(25, () -> {
-            URI found = passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER));
-            assertNotNull(found);
-            return found;
-        });
+        attempt(20, () -> assertNotNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER))));
+
+        URI id = passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER));
 
         User passUser = passClient.readResource(id, User.class);
 

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
@@ -133,7 +133,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
             Assert.assertEquals(200, response.code());
         }
         
-        URI id = attempt(15, () -> {
+        URI id = attempt(25, () -> {
             URI found = passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER));
             assertNotNull(found);
             return found;

--- a/pass-authz-integration/src/test/resources/docker/Dockerfile
+++ b/pass-authz-integration/src/test/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oapass/fcrepo:4.7.5-2.1-SNAPSHOT
+FROM oapass/fcrepo:4.7.5-2.2-SNAPSHOT
 
 COPY pass-user-service.war /usr/local/tomcat/webapps/
 COPY pass-authz-filters-shaded.jar /usr/local/tomcat/lib

--- a/pass-authz-integration/src/test/resources/docker/Dockerfile
+++ b/pass-authz-integration/src/test/resources/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM oapass/fcrepo:4.7.5-2.2-SNAPSHOT
 
+RUN rm -rf /usr/local/tomcat/webapps/pass-user-service
 COPY pass-user-service.war /usr/local/tomcat/webapps/
 COPY pass-authz-filters-shaded.jar /usr/local/tomcat/lib
 COPY conf/* /usr/local/tomcat/conf/

--- a/pass-user-service/pom.xml
+++ b/pass-user-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>pass-user-service</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-authz</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>pass-authz-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.18.0</mockito.version>
     <okhttp.version>3.9.0</okhttp.version>
-    <pass.fedora.client.version>0.3.1-SNAPSHOT</pass.fedora.client.version>
+    <pass.fedora.client.version>0.3.2-SNAPSHOT</pass.fedora.client.version>
 
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>


### PR DESCRIPTION
Question for reviewer: does this need to change?
https://github.com/OA-PASS/pass-authz/blob/b5da1117faecc7a1dbb3ef9227fc45c16c29322c/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthRolesProvider.java#L52