### PR TITLE
Add body to 401 response, increment version 

### DIFF
--- a/pass-authz-acl/pom.xml
+++ b/pass-authz-acl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-acl</artifactId>
 

--- a/pass-authz-core/pom.xml
+++ b/pass-authz-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-core</artifactId>
 

--- a/pass-authz-filters/pom.xml
+++ b/pass-authz-filters/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-filters</artifactId>
 

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-integration</artifactId>
 

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
@@ -64,6 +64,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         Request get = buildShibRequest(shibHeaders);
         try (Response response = httpClient.newCall(get).execute()) {
             Assert.assertEquals(401, response.code());
+            Assert.assertEquals("Unauthorized", response.body().string());
         }
 
         final PassClient passClient = PassClientFactory.getPassClient();

--- a/pass-authz-tools/pom.xml
+++ b/pass-authz-tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-authz-tools</artifactId>
 

--- a/pass-user-service/pom.xml
+++ b/pass-user-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-authz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-user-service</artifactId>
   <packaging>war</packaging>

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -152,7 +152,10 @@ public class UserServlet extends HttpServlet {
             }
         } else {
             LOG.info("{} not authorized", shibUser.getPrincipal());
-            response.setStatus(401);
+            try (Writer out = response.getWriter()) {
+                response.setStatus(401);
+                out.append("Unauthorized");
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-authz</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>pass-authz-core</module>


### PR DESCRIPTION
This is workaround for an issue where Ember does not receive all of the properties of a 401 error, but does receive the response body for some reason. This gives Ember something to use in order to determine whether a 401 page should be displayed.

Incremented version to `0.1.1-SNAPSHOT` for release