### PR TITLE
Remove individual ACLs for grants

### DIFF
--- a/pass-authz-acl/src/main/resources/containers.yml
+++ b/pass-authz-acl/src/main/resources/containers.yml
@@ -38,6 +38,7 @@ containers:
   - grants:
       read:
         - admin
+        - submitter
       write:
         - pass-backend
 

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PassAuthzIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PassAuthzIT.java
@@ -96,7 +96,7 @@ public class PassAuthzIT extends FcrepoIT {
                 .perform();
 
         // This will wait until we have a lookup in the index
-        assertEquals(userUri, attempt(30, () -> {
+        assertEquals(userUri, attempt(60, () -> {
             final URI found = client.findByAttribute(User.class, "localKey", user.getLocalKey());
             assertNotNull(found);
             return found;

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/AuthzListener.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/AuthzListener.java
@@ -32,8 +32,6 @@ public class AuthzListener {
 
     String SUBMISSION_TYPE = "http://oapass.org/ns/pass#Submission";
 
-    String GRANT_TYPE = "http://oapass.org/ns/pass#Grant";
-
     private final ConnectionFactory factory;
 
     private final PolicyEngine aclPolicies;
@@ -61,9 +59,6 @@ public class AuthzListener {
                         if (types.contains(SUBMISSION_TYPE)) {
                             aclPolicies.updateSubmission(fm.getResourceURI());
                             LOG.debug("Handling Submission message for {} ", fm.getAction());
-                        } else if (types.contains(GRANT_TYPE)) {
-                            LOG.debug("Handling Grant message for {}", fm.getAction());
-                            aclPolicies.updateGrant(fm.getResourceURI());
                         } else {
                             LOG.debug("Ignoring message with irrelevant types ", types);
                         }

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/AuthzListenerService.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/AuthzListenerService.java
@@ -51,6 +51,7 @@ public class AuthzListenerService {
         final PolicyEngine policies = new PolicyEngine(client, manager);
         policies.setBackendRole(ofNullable(getValue("pass.backend.role")).map(URI::create).orElse(null));
         policies.setAdminRole(ofNullable(getValue("pass.grantadmin.role")).map(URI::create).orElse(null));
+        policies.setSubmitterRole(ofNullable(getValue("pass.submitter.role")).map(URI::create).orElse(null));
 
         final AuthzListener listener = new AuthzListener(buildConnectionFactory(), policies, queue);
 

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
@@ -40,6 +40,8 @@ public class PermissionsUpdater {
 
     static final URI PASS_GRANTADMIN_ROLE = URI.create("http://oapass.org/ns/roles/johnshopkins.edu#admin");
 
+    static final URI PASS_SUBMITTER_ROLE = URI.create("http://oapass.org/ns/roles/johnshopkins.edu#submitter");
+
     static final Logger LOG = LoggerFactory.getLogger(PermissionsUpdater.class);
 
     static final ExecutorService exe = Executors.newCachedThreadPool();
@@ -53,6 +55,7 @@ public class PermissionsUpdater {
         final PolicyEngine authzPolicy = new PolicyEngine(client, manager);
         authzPolicy.setBackendRole(PASS_BACKEND_ROLE);
         authzPolicy.setAdminRole(PASS_GRANTADMIN_ROLE);
+        authzPolicy.setSubmitterRole(PASS_SUBMITTER_ROLE);
 
         final ContainerVisitor crawler = new ContainerVisitor();
 
@@ -61,11 +64,7 @@ public class PermissionsUpdater {
                 "submissions"),
                 authzPolicy::updateSubmission));
 
-        LOG.info("Visiting grants");
-        final Future<Integer> grants = exe.submit(() -> crawler.visit(URI.create(FedoraConfig.getBaseUrl() +
-                "grants"), authzPolicy::updateGrant));
-
-        LOG.info("Updated {} submissions and {} grants", submissions.get(), grants.get());
+        LOG.info("Updated {} submissions", submissions.get());
 
     }
 }


### PR DESCRIPTION
Updates the `PolicyEngine` and ITs so that grants do _not_ have individual ACLs.   The end result is that grants retain default permissions (readable by submitters, admins, writable by backend only).

Individual ACLs are still enabled for submissions, such that:
* Everybody (grant, admin) can always read every submission
* Any submitter can create a submission
* A submission can only be modified by the User associated with it, and only if it has not been designated `submitted=true`
* A submission with `submitted = true` is writable only by PASS backend services

