### PR TITLE
Fix duplicate user by creating Users in a critical section

### DIFF
--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUserProvider.java
@@ -16,12 +16,45 @@
 
 package org.dataconservancy.pass.authz;
 
+import java.util.function.Function;
+
 import javax.servlet.http.HttpServletRequest;
 
 /**
+ * Provides details about authenticated users given an http request.
+ *
  * @author apb@jhu.edu
  */
 public interface AuthUserProvider {
 
-    public AuthUser getUser(HttpServletRequest request);
+    /**
+     * Get theauthenticated user from the current http request.
+     * <p>
+     * Inspects the http request for the current user/principal, and provides information about that user
+     * <p>
+     *
+     * @param request the curent http request.
+     * @return
+     */
+    AuthUser getUser(HttpServletRequest request);
+
+    /**
+     * Get the authenticated user, and filter the result before returning. *
+     * <p>
+     * Inspects the http request for the current user/principal, and provides information about that user. Invokes the
+     * provided function to map/transform/inspect the authenticated user. The primary use case is filter for "create
+     * if not present".
+     * <p>
+     *
+     * @param request
+     * @param filterWhenDone
+     * @return
+     */
+    public default AuthUser getUser(HttpServletRequest request, Function<AuthUser, AuthUser> filterWhenDone) {
+        if (filterWhenDone != null) {
+            return filterWhenDone.apply(getUser(request));
+        } else {
+            return getUser(request);
+        }
+    }
 }

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ExpiringLRUCache.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ExpiringLRUCache.java
@@ -155,7 +155,7 @@ public class ExpiringLRUCache<K, V> {
             }
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
-            return null;
+            throw new RuntimeException("Read from cache was interrupted");
         }
     }
 }

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -102,13 +102,15 @@ public class ShibAuthUserProvider implements AuthUserProvider {
 
         boolean isFaculty = false;
 
-        if (LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled() && request != null) {
 
             LOG.debug("Request headers: ");
             final Enumeration<String> headerNames = request.getHeaderNames();
-            while (headerNames.hasMoreElements()) {
-                final String name = headerNames.nextElement();
-                LOG.debug("   " + name + ": " + request.getHeader(name));
+            if (headerNames != null) {
+                while (headerNames.hasMoreElements()) {
+                    final String name = headerNames.nextElement();
+                    LOG.debug("   " + name + ": " + request.getHeader(name));
+                }
             }
         }
 
@@ -162,8 +164,7 @@ public class ShibAuthUserProvider implements AuthUserProvider {
                 user.setId(id);
                 LOG.debug("User resource for {} is {}", employeeId, id);
             } catch (final Exception e) {
-                LOG.warn("Error looking up user with employee id " + employeeId,
-                        e);
+                throw new RuntimeException("Error while looking up user by localKey" + employeeId, e);
             }
         } else {
             LOG.debug("No shibboleth employee id; skipping user lookup ");

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -172,33 +172,10 @@ public class ShibAuthUserProvider implements AuthUserProvider {
         return user;
     }
 
-    /**
-     * Checks for User record by employeeId. This depends on the user being indexed, so will retry a number of times
-     * before returning null to make sure there is time for indexing of a new user to happen. Note that RETRIES is set
-     * to 5, this is based on current configuration of index refresh rate at 1 second
-     *
-     * @param employeeId
-     * @return
-     */
     private URI findUserId(String employeeId) {
-        final int RETRIES = 1;
-        for (int tries = 0; tries < RETRIES; tries++) {
-            final URI userId = passClient.findByAttribute(User.class, "localKey", employeeId);
-            if (userId != null) {
-                return userId;
-            } else if (tries + 1 < RETRIES) { // Don't bother delay on the final one
-                try {
-                    LOG.debug("Could not find User record for employee {}, waiting and trying again (try #{})",
-                            employeeId, tries);
-                    Thread.sleep(1000);
-                } catch (final InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                    LOG.warn("Thread was interrupted while waiting to retry employee {} lookup.", employeeId);
-                }
-            }
-        }
-        LOG.info("User with employee id {} was not found before timeout", employeeId);
-        return null;
+
+        return passClient.findByAttribute(User.class, "localKey", employeeId);
+
     }
 
     private <T> T getShibAttr(HttpServletRequest request, String name, Function<String, T> transform) {

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -85,6 +85,11 @@ public class ShibAuthUserProvider implements AuthUserProvider {
         userCache = cache;
     }
 
+    @Override
+    public AuthUser getUser(HttpServletRequest request) {
+        return getUser(request, (u) -> u);
+    }
+
     /**
      * This method reads the shib headers and uses the values to populate an {@link AuthUser} object, which is
      * consumed by the {@code UserServlet} to build a {@code User} object for the back-end storage system.
@@ -93,7 +98,7 @@ public class ShibAuthUserProvider implements AuthUserProvider {
      * @return the populated AuthUser
      */
     @Override
-    public AuthUser getUser(HttpServletRequest request) {
+    public AuthUser getUser(HttpServletRequest request, Function<AuthUser, AuthUser> doAfter) {
 
         boolean isFaculty = false;
 
@@ -123,22 +128,6 @@ public class ShibAuthUserProvider implements AuthUserProvider {
             }
         }
 
-        URI id = null;
-        if (employeeId != null) {
-            LOG.debug("Looking up User based in employeeId '{}'", employeeId);
-            try {
-                id = userCache.getOrDo(employeeId,
-                        () -> findUserId(employeeId));
-                LOG.debug("User resource for {} is {}", employeeId, id);
-            } catch (final Exception e) {
-                LOG.warn("Error looking up user with employee id " + employeeId,
-                        e);
-            }
-        } else {
-            LOG.debug("No shibboleth employee id; skipping user lookup ");
-            id = null;
-        }
-
         final AuthUser user = new AuthUser();
         user.setEmployeeId(employeeId);
         user.setName(displayName);
@@ -147,7 +136,6 @@ public class ShibAuthUserProvider implements AuthUserProvider {
             user.setInstitutionalId(institutionalId.toLowerCase());// this is our normal format
         }
         user.setFaculty(isFaculty);
-        user.setId(id);
         user.setPrincipal(getShibAttr(request, EPPN_HEADER, s -> s));
 
         ofNullable(user.getPrincipal())
@@ -161,38 +149,58 @@ public class ShibAuthUserProvider implements AuthUserProvider {
                         .map(sa -> sa.split("@")[1])
                         .collect(toSet()));
 
+        if (employeeId != null) {
+            LOG.debug("Looking up User based in employeeId '{}'", employeeId);
+            try {
+                final URI id = userCache.getOrDo(employeeId,
+                        () -> {
+                            user.setId(findUserId(employeeId));
+                            final AuthUser filtered = doAfter.apply(user);
+                            return filtered.getId();
+                        });
+
+                user.setId(id);
+                LOG.debug("User resource for {} is {}", employeeId, id);
+            } catch (final Exception e) {
+                LOG.warn("Error looking up user with employee id " + employeeId,
+                        e);
+            }
+        } else {
+            LOG.debug("No shibboleth employee id; skipping user lookup ");
+        }
+
         return user;
     }
-    
 
     /**
-     * Checks for User record by employeeId. This depends on the user being indexed, 
-     * so will retry a number of times before returning null to make sure there is time for indexing 
-     * of a new user to happen. Note that RETRIES is set to 5, this is based on current configuration 
-     * of index refresh rate at 1 second
+     * Checks for User record by employeeId. This depends on the user being indexed, so will retry a number of times
+     * before returning null to make sure there is time for indexing of a new user to happen. Note that RETRIES is set
+     * to 5, this is based on current configuration of index refresh rate at 1 second
+     *
      * @param employeeId
      * @return
      */
     private URI findUserId(String employeeId) {
-        final int RETRIES = 5;
+        final int RETRIES = 1;
         for (int tries = 0; tries < RETRIES; tries++) {
-            URI userId = passClient.findByAttribute(User.class, "localKey", employeeId);
-            if (userId!=null) {
+            final URI userId = passClient.findByAttribute(User.class, "localKey", employeeId);
+            if (userId != null) {
                 return userId;
-            } else {
+            } else if (tries + 1 < RETRIES) { // Don't bother delay on the final one
                 try {
-                    LOG.debug("Could not find User record for employee {}, waiting and trying again (try #{})", employeeId, tries);
+                    LOG.debug("Could not find User record for employee {}, waiting and trying again (try #{})",
+                            employeeId, tries);
                     Thread.sleep(1000);
-                } catch (InterruptedException ex) {
+                } catch (final InterruptedException ex) {
                     Thread.currentThread().interrupt();
                     LOG.warn("Thread was interrupted while waiting to retry employee {} lookup.", employeeId);
                 }
-            }                
+            }
         }
-        LOG.warn("User with employee id {} was not found before timeout", employeeId);
+        LOG.info("User with employee id {} was not found before timeout", employeeId);
         return null;
     }
-    
+
     private <T> T getShibAttr(HttpServletRequest request, String name, Function<String, T> transform) {
         final T value = transform(ofNullable(request.getAttribute(name))
                 .map(Object::toString)

--- a/pass-authz-core/src/test/resources/logback-test.xml
+++ b/pass-authz-core/src/test/resources/logback-test.xml
@@ -28,5 +28,7 @@
     <appender-ref ref="STDOUT" />
 
   </root>
+  
+  <logger name="org.dataconservancy.pass.authz" level="TRACE" />
 
 </configuration>


### PR DESCRIPTION
`ExpiringLRUCache` provides a critical section for dong some 'computation' of a cached value if it is not already present in the cache.  At the moment, as far as the User service is concerned, lookup of Users occurs in that critical section, but creation does not.  This refactors the situation so that the lookup _and_ creation occurs in the critical section, and results are cached.  This eliminates the need to search for users by their `localKey` immediately after they are created, which makes the process immune to normal async lags in indexing.

Also removes the retry logic for lookup of users, and expands tests

Resolves #33 