### PR TITLE
Ensure the user service responds with a User in JSON-LD

### DIFF
--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/ShibAuthUserServiceIT.java
@@ -16,27 +16,6 @@
 
 package org.dataconservancy.pass.authz;
 
-import okhttp3.Credentials;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import org.dataconservancy.pass.client.PassClient;
-import org.dataconservancy.pass.client.PassClientFactory;
-import org.dataconservancy.pass.client.fedora.FedoraConfig;
-import org.dataconservancy.pass.model.User;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -45,6 +24,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.client.PassJsonAdapter;
+import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
+import org.dataconservancy.pass.client.fedora.FedoraConfig;
+import org.dataconservancy.pass.model.User;
+
+import org.apache.activemq.util.ByteArrayInputStream;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 /**
  * @author apb@jhu.edu
@@ -52,26 +54,30 @@ import java.util.Set;
 public class ShibAuthUserServiceIT extends FcrepoIT {
 
     private static final String SHIB_DISPLAYNAME_HEADER = "Displayname";
+
     private static final String SHIB_MAIL_HEADER = "Mail";
+
     private static final String SHIB_EPPN_HEADER = "Eppn";
+
     private static final String SHIB_UNSCOPED_AFFILIATION_HEADER = "Unscoped-Affiliation";
+
     private static final String SHIB_SCOPED_AFFILIATION_HEADER = "Affiliation";
+
     private static final String SHIB_EMPLOYEE_NUMBER_HEADER = "Employeenumber";
-    
-    private final ObjectMapper mapper = new ObjectMapper();
-    
+
+    PassJsonAdapter json = new PassJsonAdapterBasic();
+
     final PassClient passClient = PassClientFactory.getPassClient();
-    
+
     OkHttpClient httpClient = new OkHttpClient.Builder()
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .build();
 
-
     @Test
     public void testGivenUserDoesNotExistNotFacultyReturns401() throws Exception {
 
-        Map<String, String> shibHeaders = new HashMap<>();
+        final Map<String, String> shibHeaders = new HashMap<>();
         shibHeaders.put(SHIB_DISPLAYNAME_HEADER, "Elmer Fudd");
         shibHeaders.put(SHIB_MAIL_HEADER, "elmer@jhu.edu");
         shibHeaders.put(SHIB_EPPN_HEADER, "efudd1@jhu.edu");
@@ -79,7 +85,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         shibHeaders.put(SHIB_SCOPED_AFFILIATION_HEADER, "HUNTER@jhu.edu;MILLIONAIRE@jhu.edu");
         shibHeaders.put(SHIB_EMPLOYEE_NUMBER_HEADER, "08675309");
 
-        Request get = buildShibRequest(shibHeaders);
+        final Request get = buildShibRequest(shibHeaders);
         try (Response response = httpClient.newCall(get).execute()) {
             Assert.assertEquals(401, response.code());
             Assert.assertEquals("Unauthorized", response.body().string());
@@ -87,25 +93,26 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
 
         final PassClient passClient = PassClientFactory.getPassClient();
         attempt(20, () -> {
-            Assert.assertNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER)));
+            Assert.assertNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(
+                    SHIB_EMPLOYEE_NUMBER_HEADER)));
         });
     }
 
     @Test
     public void testGivenUserDoesExistReturns200() throws Exception {
 
-        User newUser = new User();
+        final User newUser = new User();
         newUser.setFirstName("Bugs");
         newUser.setLastName("Bunny");
         newUser.setLocalKey("10933511");
         newUser.getRoles().add(User.Role.SUBMITTER);
 
         final PassClient passClient = PassClientFactory.getPassClient();
-        URI id = passClient.createResource(newUser);
+        final URI id = passClient.createResource(newUser);
 
         attempt(20, () -> Assert.assertNotNull(passClient.findByAttribute(User.class, "localKey", "10933511")));
 
-        Map<String, String> shibHeaders = new HashMap<>();
+        final Map<String, String> shibHeaders = new HashMap<>();
         shibHeaders.put(SHIB_DISPLAYNAME_HEADER, "Bugs Bunny");
         shibHeaders.put(SHIB_MAIL_HEADER, "bugs@jhu.edu");
         shibHeaders.put(SHIB_EPPN_HEADER, "bbunny1@jhu.edu");
@@ -113,24 +120,29 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         shibHeaders.put(SHIB_SCOPED_AFFILIATION_HEADER, "SOCIOPATH@jhu.edu;FACULTY@jhu.edu");
         shibHeaders.put(SHIB_EMPLOYEE_NUMBER_HEADER, "10933511");
 
-        Request get = buildShibRequest(shibHeaders);
+        final Request get = buildShibRequest(shibHeaders);
+        final User fromResponse;
         try (Response response = httpClient.newCall(get).execute()) {
+            final byte[] body = response.body().bytes();
+            fromResponse = json.toModel(body, User.class);
             Assert.assertEquals(200, response.code());
+            assertIsjsonld(body);
         }
 
-        User passUser = passClient.readResource(id, User.class);
+        final User passUser = passClient.readResource(id, User.class);
 
-        //these fields should be updated on this user
+        // these fields should be updated on this user
         Assert.assertEquals("bbunny1", passUser.getInstitutionalId());
-        Assert.assertEquals("Bugs Bunny",passUser.getDisplayName());
+        Assert.assertEquals("Bugs Bunny", passUser.getDisplayName());
         Assert.assertEquals("bugs@jhu.edu", passUser.getEmail());
+        Assert.assertEquals(passUser, fromResponse);
 
     }
 
     @Test
     public void testGivenUserDoesNotExistIsFacultyReturns200() throws Exception {
 
-        Map<String, String> shibHeaders = new HashMap<>();
+        final Map<String, String> shibHeaders = new HashMap<>();
         shibHeaders.put(SHIB_DISPLAYNAME_HEADER, "Daffy Duck");
         shibHeaders.put(SHIB_MAIL_HEADER, "daffy@jhu.edu");
         shibHeaders.put(SHIB_EPPN_HEADER, "dduck1@jhu.edu");
@@ -138,25 +150,33 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         shibHeaders.put(SHIB_SCOPED_AFFILIATION_HEADER, "TARGET@jhu.edu;FACULTY@jhmi.edu");
         shibHeaders.put(SHIB_EMPLOYEE_NUMBER_HEADER, "10020030");
 
-        Assert.assertNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(SHIB_EMPLOYEE_NUMBER_HEADER)));
+        Assert.assertNull(passClient.findByAttribute(User.class, "localKey", shibHeaders.get(
+                SHIB_EMPLOYEE_NUMBER_HEADER)));
 
-        Request get = buildShibRequest(shibHeaders);
+        final Request get = buildShibRequest(shibHeaders);
+        final User fromResponse;
         try (Response response = httpClient.newCall(get).execute()) {
+            final byte[] body = response.body().bytes();
+            fromResponse = json.toModel(body, User.class);
             Assert.assertEquals(200, response.code());
+            assertIsjsonld(body);
         }
-        
-        URI id = attempt(30, () -> Optional.ofNullable(passClient.findByAttribute(User.class, "localKey", shibHeaders
-                .get(SHIB_EMPLOYEE_NUMBER_HEADER))).orElseThrow(() -> new NullPointerException("Did not find result from localKey search")));
 
-        User passUser = passClient.readResource(id, User.class);
+        final URI id = attempt(30, () -> Optional.ofNullable(passClient.findByAttribute(User.class, "localKey",
+                shibHeaders
+                        .get(SHIB_EMPLOYEE_NUMBER_HEADER))).orElseThrow(() -> new NullPointerException(
+                                "Did not find result from localKey search")));
+
+        final User passUser = passClient.readResource(id, User.class);
 
         Assert.assertEquals(shibHeaders.get(SHIB_DISPLAYNAME_HEADER), passUser.getDisplayName());
         Assert.assertEquals(shibHeaders.get(SHIB_MAIL_HEADER), passUser.getEmail());
         Assert.assertEquals("dduck1", passUser.getInstitutionalId());
+        Assert.assertEquals(passUser, fromResponse);
 
     }
-    
-    /* Makes sure that only one new user is created in the fase of multiple cuncurrent requests */
+
+    /* Makes sure that only one new user is created in the fase of multiple concurrent requests */
     @Test
     public void testConcurrentNewUser() throws Exception {
         final ExecutorService exe = Executors.newFixedThreadPool(8);
@@ -179,7 +199,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
             results.add(exe.submit(() -> {
                 try (Response response = httpClient.newCall(get).execute()) {
                     Assert.assertEquals(200, response.code());
-                    return mapper.reader().treeToValue(mapper.readTree(response.body().string()), User.class);
+                    return json.toModel(response.body().bytes(), User.class);
                 }
             }));
         }
@@ -189,7 +209,7 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
                     try {
                         return f.get();
                     } catch (final Exception e) {
-                        throw new RuntimeException();
+                        throw new RuntimeException(e);
                     }
                 })
                 .map(User::getId)
@@ -204,8 +224,8 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
         exe.shutdown();
     }
 
-    private Request buildShibRequest(Map<String,String> headers) throws MalformedURLException {
-        String fedora_credentials = Credentials.basic(FedoraConfig.getUserName(), FedoraConfig.getPassword());
+    private Request buildShibRequest(Map<String, String> headers) throws MalformedURLException {
+        final String fedora_credentials = Credentials.basic(FedoraConfig.getUserName(), FedoraConfig.getPassword());
         return new Request.Builder().url(USER_SERVICE_URI.toURL())
                 .header("Authorization", fedora_credentials)
                 .header(SHIB_DISPLAYNAME_HEADER, headers.get(SHIB_DISPLAYNAME_HEADER))
@@ -215,5 +235,14 @@ public class ShibAuthUserServiceIT extends FcrepoIT {
                 .header(SHIB_SCOPED_AFFILIATION_HEADER, headers.get(SHIB_SCOPED_AFFILIATION_HEADER))
                 .header(SHIB_EMPLOYEE_NUMBER_HEADER, headers.get(SHIB_EMPLOYEE_NUMBER_HEADER))
                 .build();
+    }
+
+    // Just make sure a body is parseable as jsonld, we really don't care what's in it, just that it has some
+    // statements.
+    @SuppressWarnings("resource")
+    private static void assertIsjsonld(byte[] body) {
+        final Model model = ModelFactory.createDefaultModel();
+        model.read(new ByteArrayInputStream(body), null, "JSON-LD");
+        Assert.assertTrue(model.listStatements().toList().size() > 3);
     }
 }

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -17,6 +17,7 @@
 package org.dataconservancy.pass.authz.service.user;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,13 +34,12 @@ import org.dataconservancy.pass.authz.LogUtil;
 import org.dataconservancy.pass.authz.ShibAuthUserProvider;
 import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.client.PassJsonAdapter;
+import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
 import org.dataconservancy.pass.model.User;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This class gets an {@link AuthUser} object from the {@link ShibAuthUserProvider} and creates {@link User} to be
@@ -53,7 +53,7 @@ public class UserServlet extends HttpServlet {
 
     static final Logger LOG = LoggerFactory.getLogger(UserServlet.class);
 
-    final ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
+    PassJsonAdapter json = new PassJsonAdapterBasic();
 
     PassClient fedoraClient = PassClientFactory.getPassClient();
 
@@ -159,8 +159,8 @@ public class UserServlet extends HttpServlet {
 
             rewriteUri(user, request);
 
-            try (Writer out = response.getWriter()) {
-                mapper.writerWithDefaultPrettyPrinter().writeValue(out, user);
+            try (OutputStream out = response.getOutputStream()) {
+                out.write(json.toJson(user, true));
                 response.setStatus(200);
             }
         } else {


### PR DESCRIPTION
* Uses the JSON adapter from the PASS client for serialization, rather than directly using Jackson
* Enhances ITs to look for the proper JSON-LD User format in responses.

Resolves #36 