### PR TITLE
Add immutability to submissionEvents, and test

### DIFF
--- a/pass-authz-acl/src/main/java/org/dataconservancy/pass/authz/acl/PolicyEngine.java
+++ b/pass-authz-acl/src/main/java/org/dataconservancy/pass/authz/acl/PolicyEngine.java
@@ -93,11 +93,34 @@ public class PolicyEngine {
             authReaders.add(submitterRole);
         }
 
-        LOG.debug("Granding read of submission {} to {}", authReaders);
+        LOG.debug("Granting read of submission {} to {}", authReaders);
         LOG.debug("Granting write on submission {} to {}", uri, authWriters);
         acls.setPermissions(uri)
                 .grantRead(authReaders)
                 .grantWrite(authWriters)
                 .perform();
     }
+
+    public void updateSubmissionEvent(URI eventUri) {
+
+        final Set<URI> authReaders = new HashSet<>();
+
+        if (backendRole != null) {
+            authReaders.add(backendRole);
+        }
+
+        if (grantAdminRole != null) {
+            authReaders.add(grantAdminRole);
+        }
+
+        if (submitterRole != null) {
+            authReaders.add(submitterRole);
+        }
+
+        LOG.debug("Making submissionEvent {} immutable, but granting read to {}", eventUri, authReaders);
+        acls.setPermissions(eventUri)
+                .grantRead(authReaders)
+                .perform();
+    }
+
 }

--- a/pass-authz-acl/src/test/java/org/dataconservancy/pass/authz/acl/PolicyEngineTest.java
+++ b/pass-authz-acl/src/test/java/org/dataconservancy/pass/authz/acl/PolicyEngineTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.authz.acl;
+
+import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.Submission;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PolicyEngineTest {
+
+    final URI ADMIN_ROLE = URI.create("http://example.org/admin");
+
+    final URI BACKEND_ROLE = URI.create("http://example.org/backend");
+
+    final URI SUBMITTER_ROLE = URI.create("http://example.org/submitter");
+
+    @Mock
+    ACLManager aclManager;
+
+    @Mock
+    PassClient client;
+
+    @Mock
+    ACLManager.Builder builder;
+
+    PolicyEngine toTest;
+
+    @Before
+    public void setUp() {
+        toTest = new PolicyEngine(client, aclManager);
+        when(aclManager.setPermissions(any())).thenReturn(builder);
+        when(builder.grantRead(any())).thenReturn(builder);
+        when(builder.grantWrite(any())).thenReturn(builder);
+    }
+
+    // If the submission is in a read-only state, then it's read only except to backend.
+    @Test
+    public void updateSubmissionReadOnlyTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+
+        toTest.setAdminRole(ADMIN_ROLE);
+        toTest.setBackendRole(BACKEND_ROLE);
+        toTest.setSubmitterRole(SUBMITTER_ROLE);
+
+        final Submission submission = new Submission();
+        submission.setSubmitted(true);
+        when(client.readResource(eq(RESOURCE_URI), eq(Submission.class))).thenReturn(submission);
+
+        toTest.updateSubmission(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.containsAll(asList(ADMIN_ROLE, BACKEND_ROLE,
+                SUBMITTER_ROLE)) && l.size() == 3));
+
+        verify(builder, times(1)).grantWrite(argThat(l -> l.containsAll(asList(BACKEND_ROLE)) && l.size() == 1));
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+
+    @Test
+    public void updateSubmissionReadOnlyNoRolesTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+
+        final Submission submission = new Submission();
+        submission.setSubmitted(true);
+        when(client.readResource(eq(RESOURCE_URI), eq(Submission.class))).thenReturn(submission);
+
+        toTest.updateSubmission(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.isEmpty()));
+
+        verify(builder, times(1)).grantWrite(argThat(l -> l.isEmpty()));
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+
+    @Test
+    public void updateSubmissionSubmitterTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+        final URI SUBMITTER_URI = URI.create("http://example.org/submitter");
+
+        toTest.setAdminRole(ADMIN_ROLE);
+        toTest.setBackendRole(BACKEND_ROLE);
+        toTest.setSubmitterRole(SUBMITTER_ROLE);
+
+        final Submission submission = new Submission();
+        submission.setSubmitted(false);
+        submission.setSubmitter(SUBMITTER_URI);
+        when(client.readResource(eq(RESOURCE_URI), eq(Submission.class))).thenReturn(submission);
+
+        toTest.updateSubmission(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.containsAll(asList(ADMIN_ROLE, BACKEND_ROLE,
+                SUBMITTER_ROLE)) && l.size() == 3));
+
+        verify(builder, times(1)).grantWrite(argThat(l -> l.containsAll(asList(BACKEND_ROLE, SUBMITTER_URI)) && l
+                .size() == 2));
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+
+    @Test
+    public void updateSubmissionPreparersTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+        final URI PREPARER_URI_1 = URI.create("http://example.org/preparer#1");
+        final URI PREPARER_URI_2 = URI.create("http://example.org/preparer#2");
+
+        toTest.setAdminRole(ADMIN_ROLE);
+        toTest.setBackendRole(BACKEND_ROLE);
+        toTest.setSubmitterRole(SUBMITTER_ROLE);
+
+        final Submission submission = new Submission();
+        submission.setSubmitted(false);
+        submission.getPreparers().addAll(asList(PREPARER_URI_1, PREPARER_URI_2));
+        when(client.readResource(eq(RESOURCE_URI), eq(Submission.class))).thenReturn(submission);
+
+        toTest.updateSubmission(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.containsAll(asList(ADMIN_ROLE, BACKEND_ROLE,
+                SUBMITTER_ROLE)) && l.size() == 3));
+
+        verify(builder, times(1)).grantWrite(argThat(l -> l.containsAll(asList(BACKEND_ROLE, PREPARER_URI_1,
+                PREPARER_URI_2)) && l
+                        .size() == 3));
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+
+    // SubmissionEvents are immutable, grant read to all foundational roles, but no write.
+    @Test
+    public void submissionEventTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+
+        toTest.setAdminRole(ADMIN_ROLE);
+        toTest.setBackendRole(BACKEND_ROLE);
+        toTest.setSubmitterRole(SUBMITTER_ROLE);
+
+        toTest.updateSubmissionEvent(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.containsAll(asList(ADMIN_ROLE, BACKEND_ROLE,
+                SUBMITTER_ROLE)) && l.size() == 3));
+
+        verify(builder, times(0)).grantWrite(any());
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+
+    // If there are no roles set, no permissions get granted
+    @Test
+    public void submissionEventNoRolesTest() {
+        final URI RESOURCE_URI = URI.create("http://example.org/resource");
+
+        toTest.updateSubmissionEvent(RESOURCE_URI);
+
+        verify(aclManager).setPermissions(eq(RESOURCE_URI));
+        verify(builder, times(1)).grantRead(argThat(l -> l.isEmpty()));
+        verify(builder, times(0)).grantWrite(any());
+        verify(builder, times(0)).grantAppend(any());
+
+        verify(builder, times(1)).perform();
+    }
+}

--- a/pass-authz-listener/src/main/java/org/dataconservancy/pass/authz/listener/AuthzListener.java
+++ b/pass-authz-listener/src/main/java/org/dataconservancy/pass/authz/listener/AuthzListener.java
@@ -32,6 +32,8 @@ public class AuthzListener {
 
     String SUBMISSION_TYPE = "http://oapass.org/ns/pass#Submission";
 
+    String SUBMISSION_EVENT_TYPE = "http://oapass.org/ns/pass#SubmissionEvent";
+
     private final ConnectionFactory factory;
 
     private final PolicyEngine aclPolicies;
@@ -57,8 +59,11 @@ public class AuthzListener {
                         final List<String> types = fm.getResourceTypes();
 
                         if (types.contains(SUBMISSION_TYPE)) {
-                            aclPolicies.updateSubmission(fm.getResourceURI());
                             LOG.debug("Handling Submission message for {} ", fm.getAction());
+                            aclPolicies.updateSubmission(fm.getResourceURI());
+                        } else if (types.contains(SUBMISSION_EVENT_TYPE)) {
+                            LOG.debug("Handling SubmissionEvent message for {} ", fm.getAction());
+                            aclPolicies.updateSubmissionEvent(fm.getResourceURI());
                         } else {
                             LOG.debug("Ignoring message with irrelevant types ", types);
                         }


### PR DESCRIPTION
Updates the authz listener to update ACLS to assure that submissionEvents are immutable.

Resolves #46