### PR TITLE
Use defensive copy of User when updating response URIs

### DIFF
--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -140,7 +140,7 @@ public class UserServlet extends HttpServlet {
                 out.append("Unauthorized");
             }
         } else {
-            final User user = shibUser.getUser();
+            final User user = new User(shibUser.getUser());
             rewriteUri(user, request);
 
             LOG.debug("Successfully returning User data for {}", user.getId());

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.23.0</mockito.version>
     <okhttp.version>3.11.0</okhttp.version>
-    <pass.fedora.client.version>0.4.1</pass.fedora.client.version>
+    <pass.fedora.client.version>0.4.2</pass.fedora.client.version>
     <elasticsearch.version>6.2.4</elasticsearch.version>
     <slf4j.version>1.7.25</slf4j.version>
     <apache.log.api>2.11.1</apache.log.api>


### PR DESCRIPTION
This will keep the cached `User` values clean, allowing `AuthRolesProvider` to properly look up users using the correct URIs.

Resolves #63 