### PR TITLE
Remove unused listener artifact in pom

### DIFF
--- a/pass-authz-tools/pom.xml
+++ b/pass-authz-tools/pom.xml
@@ -15,32 +15,6 @@
         <version>3.0.0</version>
         <executions>
           <execution>
-            <id>listener</id>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>listener-exe</shadedClassifierName>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>org.dataconservancy.pass.authz.listener.AuthzListenerService</mainClass>
-                </transformer>
-              </transformers>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
-          </execution>
-          <execution>
             <id>container-permissions</id>
             <goals>
               <goal>shade</goal>


### PR DESCRIPTION
This was a leftover from before a refactoring, and is no longer used here.  The real listener artifact is created in pass-authz-listener