### PR TITLE
Use submitterEmail() algorithm for user tokens

### DIFF
--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/UserServiceIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/UserServiceIT.java
@@ -55,10 +55,10 @@ import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
 import org.dataconservancy.pass.client.util.ConfigUtil;
 import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.User;
+import org.dataconservancy.pass.model.support.Identifier;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.dataconservancy.pass.model.support.Identifier;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
 import org.junit.Assert;
 import org.junit.Test;
@@ -82,6 +82,7 @@ public class UserServiceIT extends FcrepoIT {
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .build();
+
     String domain = "johnshopkins.edu";
 
     @Test
@@ -90,11 +91,11 @@ public class UserServiceIT extends FcrepoIT {
         final User newUser = new User();
         newUser.setFirstName("Bugs");
         newUser.setLastName("Bunny");
-        String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE,"10933511").serialize();
+        final String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE, "10933511").serialize();
         newUser.getLocatorIds().add(eeId);
-        String hkId = new Identifier(domain, HOPKINS_ID_TYPE, "LSDFER").serialize();
+        final String hkId = new Identifier(domain, HOPKINS_ID_TYPE, "LSDFER").serialize();
         newUser.getLocatorIds().add(hkId);
-        newUser.getLocatorIds().add(new Identifier(domain, JHED_ID_TYPE,"bbunny1").serialize());
+        newUser.getLocatorIds().add(new Identifier(domain, JHED_ID_TYPE, "bbunny1").serialize());
         newUser.getRoles().add(User.Role.SUBMITTER);
 
         final PassClient passClient = PassClientFactory.getPassClient();
@@ -110,7 +111,7 @@ public class UserServiceIT extends FcrepoIT {
         shibHeaders.put(EMPLOYEE_ID_HEADER, "10933511");
         shibHeaders.put(HOPKINS_ID_HEADER, "LSDFER@johnshopkins.edu");
 
-        String jhedId = new Identifier(domain, JHED_ID_TYPE, "bbunny1").serialize();
+        final String jhedId = new Identifier(domain, JHED_ID_TYPE, "bbunny1").serialize();
 
         final Request get = buildShibRequest(shibHeaders);
         final User fromResponse;
@@ -155,11 +156,11 @@ public class UserServiceIT extends FcrepoIT {
         shibHeaders.put(EPPN_HEADER, "dduck1@johnshopkins.edu");
         shibHeaders.put(HOPKINS_ID_HEADER, "DDDDDD@johnshopkins.edu");
         shibHeaders.put(SCOPED_AFFILIATION_HEADER, "TARGET@jhu.edu;STAFF@jhmi.edu");
-        String number = Integer.toString(ThreadLocalRandom.current().nextInt(1000,
+        final String number = Integer.toString(ThreadLocalRandom.current().nextInt(1000,
                 99999));
         shibHeaders.put(EMPLOYEE_ID_HEADER, number);
 
-        String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE, number).serialize();
+        final String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE, number).serialize();
 
         assertNull(passClient.findByAttribute(User.class, "locatorIds", eeId));
 
@@ -167,7 +168,8 @@ public class UserServiceIT extends FcrepoIT {
 
         // First, add a new submission, and make it writable by someone else;
         final Submission submission = new Submission();
-        submission.setSubmitter(MAILTO_PLACEHOLDER);
+        submission.setSubmitterName("My name");
+        submission.setSubmitterEmail(MAILTO_PLACEHOLDER);
         final URI SUBMISSION_URI = passClient.createResource(submission);
         new ACLManager().setPermissions(SUBMISSION_URI).grantWrite(asList(URI.create(
                 "http://example.org/nobody"))).perform();
@@ -253,7 +255,7 @@ public class UserServiceIT extends FcrepoIT {
                 .collect(Collectors.toSet());
 
         Assert.assertEquals(1, created.size());
-        String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE, "89248104").serialize();
+        final String eeId = new Identifier(domain, EMPLOYEE_ID_TYPE, "89248104").serialize();
         attempt(60, () -> {
             Assert.assertNotNull(passClient.findByAttribute(User.class, "locatorIds", eeId));
         });

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/TokenService.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/TokenService.java
@@ -80,7 +80,14 @@ class TokenService {
         return null;
     }
 
-    public boolean replacePlaceholder(User user, Token token) {
+    /**
+     * Updates the submission by validating the user token and injecting the new user.
+     *
+     * @param user The new user
+     * @param token User token
+     * @return true, if the submission is updated.
+     */
+    public boolean enactUserToken(User user, Token token) {
 
         if (user == null || user.getId() == null) {
             throw new NullPointerException("Cannot process token for a null or unidentified user");
@@ -100,11 +107,14 @@ class TokenService {
                     .getPassResource()), e);
         }
 
-        if (token.getReference().equals(submission.getSubmitter())) {
-            LOG.info("User <{}> will be made a submitter for <{}>, replacing placeholder <{}>",
+        if (token.getReference().equals(submission.getSubmitterEmail())) {
+            LOG.info("User <{}> will be made a submitter for <{}>, based on matching e-mail <{}>",
                     user.getId(),
                     submission.getId(),
-                    submission.getSubmitter());
+                    submission.getSubmitterEmail());
+
+            submission.setSubmitterEmail(null);
+            submission.setSubmitterName(null);
 
             submission.setSubmitter(user.getId());
             client.updateResource(submission);
@@ -115,8 +125,8 @@ class TokenService {
             return false;
         } else {
             final String message = format(
-                    "New user token does not match expected placeholer <%s> on submission <%s>; found <%s> instead",
-                    token.getReference(), submission.getId(), submission.getSubmitter());
+                    "New user token does not match expected e-mail <%s> on submission <%s>; found <%s> instead",
+                    token.getReference(), submission.getId(), submission.getSubmitterEmail());
 
             LOG.warn(message);
             throw new BadTokenException(message);

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -152,7 +152,7 @@ public class UserServlet extends HttpServlet {
     }
 
     private void applyUserToken(Token token, User user) {
-        if (tokenService.replacePlaceholder(user, token)) {
+        if (tokenService.enactUserToken(user, token)) {
             tokenService.addWritePermissions(user, token);
         }
     }

--- a/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
+++ b/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
@@ -347,7 +347,7 @@ public class UserServletTest {
     @Test
     public void noTokenTest() throws Exception {
         servlet.doGet(request, response);
-        verify(tokenService, times(0)).replacePlaceholder(any(User.class), any(Token.class));
+        verify(tokenService, times(0)).enactUserToken(any(User.class), any(Token.class));
         verify(response, times(1)).setStatus(eq(200));
         assertOutputEquals(USER.getUser());
     }
@@ -357,7 +357,7 @@ public class UserServletTest {
         final String queryString = "userToken=BLAH";
         when(request.getQueryString()).thenReturn(queryString);
         when(tokenService.fromQueryString(eq(queryString))).thenReturn(token);
-        when(tokenService.replacePlaceholder(any(), any())).thenThrow(BadTokenException.class);
+        when(tokenService.enactUserToken(any(), any())).thenThrow(BadTokenException.class);
 
         servlet.doGet(request, response);
         verify(response, times(1)).setStatus(eq(400));
@@ -368,10 +368,10 @@ public class UserServletTest {
         final String queryString = "userToken=BLAH";
         when(request.getQueryString()).thenReturn(queryString);
         when(tokenService.fromQueryString(eq(queryString))).thenReturn(token);
-        when(tokenService.replacePlaceholder(eq(USER.getUser()), eq(token))).thenReturn(true);
+        when(tokenService.enactUserToken(eq(USER.getUser()), eq(token))).thenReturn(true);
 
         servlet.doGet(request, response);
-        verify(tokenService, times(1)).replacePlaceholder(eq(USER.getUser()), eq(token));
+        verify(tokenService, times(1)).enactUserToken(eq(USER.getUser()), eq(token));
         verify(tokenService, times(1)).addWritePermissions(eq(USER.getUser()), eq(token));
         verify(response, times(1)).setStatus(eq(200));
         assertOutputEquals(USER.getUser());
@@ -392,10 +392,10 @@ public class UserServletTest {
 
         when(request.getQueryString()).thenReturn(queryString);
         when(tokenService.fromQueryString(eq(queryString))).thenReturn(token);
-        when(tokenService.replacePlaceholder(any(User.class), eq(token))).thenReturn(true);
+        when(tokenService.enactUserToken(any(User.class), eq(token))).thenReturn(true);
 
         servlet.doGet(request, response);
-        verify(tokenService, times(1)).replacePlaceholder(any(User.class), eq(token));
+        verify(tokenService, times(1)).enactUserToken(any(User.class), eq(token));
         verify(tokenService, times(1)).addWritePermissions(any(User.class), eq(token));
         verify(response, times(1)).setStatus(eq(200));
 
@@ -408,10 +408,10 @@ public class UserServletTest {
         final String queryString = "userToken=BLAH";
         when(request.getQueryString()).thenReturn(queryString);
         when(tokenService.fromQueryString(eq(queryString))).thenReturn(token);
-        when(tokenService.replacePlaceholder(eq(USER.getUser()), eq(token))).thenReturn(false);
+        when(tokenService.enactUserToken(eq(USER.getUser()), eq(token))).thenReturn(false);
 
         servlet.doGet(request, response);
-        verify(tokenService, times(1)).replacePlaceholder(eq(USER.getUser()), eq(token));
+        verify(tokenService, times(1)).enactUserToken(eq(USER.getUser()), eq(token));
         verify(tokenService, times(0)).addWritePermissions(any(), any());
         verify(response, times(1)).setStatus(eq(200));
         assertOutputEquals(USER.getUser());

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.23.0</mockito.version>
     <okhttp.version>3.11.0</okhttp.version>
-    <pass.fedora.client.version>0.4.2</pass.fedora.client.version>
+    <pass.fedora.client.version>0.5.0</pass.fedora.client.version>
     <elasticsearch.version>6.2.4</elasticsearch.version>
     <slf4j.version>1.7.25</slf4j.version>
     <apache.log.api>2.11.1</apache.log.api>


### PR DESCRIPTION
Previously, the user token encoded the submitter URI and a placeholder
URI.  Since emmber cannot deal with the placeholder, the model was
updated to add fields submitterName and submitterEmail, which
essentially serve as single-purpose placeholders.  Thus PR adappts the
user token algorithm to these changes.

Note:  The new mechanism is less general, and hard-wires substitution so
that it can _only_ apply to submitters (e.g. it would not be possible to
invite proxy users without a data model change).

Resolves #68 