### PR TITLE
Support submissionEvents and selecting type in CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ The applications are:
 
 Configuration:
 
-The only configuration these tools need are standard PASS java client [properties](https://github.com/OA-PASS/java-fedora-client#configuration) for Fedora username,  password, and baseURI.
+* Standard PASS java client [properties](https://github.com/OA-PASS/java-fedora-client#configuration) for Fedora username,  password, and baseURI.
+* `TYPE` (or, as a java property, `-Dtype`).  For the individual permissions updator, this specifies the type of PASS entity to update.  If not specified, it will update all.
 
 For example:
 
-    java -Dpass.fedora.baseurl=http://example.org/fcrepo/rest -Dpass.fedora.user=fedoraAdmin -Dpass.fedora.password=pass -jar pass-authz-tools-${version}-SNAPSHOT-individual-permissions-exe.jar
+    java -Dpass.fedora.baseurl=http://example.org/fcrepo/rest -Dtype=SubmissionEvent -Dpass.fedora.user=fedoraAdmin -Dpass.fedora.password=pass -jar pass-authz-tools-${version}-SNAPSHOT-individual-permissions-exe.jar
     
 ### pass-authz-usertoken
 

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
@@ -25,7 +25,9 @@ import org.dataconservancy.pass.authz.acl.ACLManager;
 import org.dataconservancy.pass.authz.acl.PolicyEngine;
 import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.client.util.ConfigUtil;
 import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.SubmissionEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,11 +57,28 @@ public class PermissionsUpdater {
         authzPolicy.setAdminRole(PASS_GRANTADMIN_ROLE);
         authzPolicy.setSubmitterRole(PASS_SUBMITTER_ROLE);
 
-        LOG.info("Visiting submissions...");
-        final Future<Integer> submissions = exe.submit(() -> client.processAllEntities(authzPolicy::updateSubmission,
-                Submission.class));
+        final String type = ConfigUtil.getSystemProperty("type", null);
 
-        LOG.info("Updated {} submissions", submissions.get());
+        System.out.println("Specified type is: " + type);
 
+        if (type == null || type.equals(Submission.class.getSimpleName())) {
+            LOG.info("Visiting submissions...");
+            final Future<Integer> submissions = exe.submit(() -> client.processAllEntities(
+                    authzPolicy::updateSubmission,
+                    Submission.class));
+
+            LOG.info("Processed {} submissions", submissions.get());
+        }
+
+        if (type == null || type.equals(SubmissionEvent.class.getSimpleName())) {
+            LOG.info("Visiting submissionEvents...");
+            final Future<Integer> submissionEvents = exe.submit(() -> client.processAllEntities(
+                    authzPolicy::updateSubmissionEvent,
+                    SubmissionEvent.class));
+
+            LOG.info("Processed {} submissionEvents", submissionEvents.get());
+        }
+
+        exe.shutdown();
     }
 }


### PR DESCRIPTION
* Iterates permissions of both Submissions and SubmissionEvents now
* Adds a system property `type` that can be used for specifying a single type to act on.
* doc updates

Resolves #60 