### PR TITLE
Address concurrency issues related to processing of new user tokens and `User` creation

### DIFF
--- a/pass-authz-acl/src/main/java/org/dataconservancy/pass/authz/acl/PolicyEngine.java
+++ b/pass-authz-acl/src/main/java/org/dataconservancy/pass/authz/acl/PolicyEngine.java
@@ -98,7 +98,7 @@ public class PolicyEngine {
             authReaders.add(submitterRole);
         }
 
-        LOG.debug("Granting read of submission {} to {}", authReaders);
+        LOG.debug("Granting read of submission {} to {}", uri, authReaders);
         LOG.debug("Granting write on submission {} to {}", uri, authWriters);
         acls.setPermissions(uri)
                 .grantRead(authReaders)

--- a/pass-authz-core/pom.xml
+++ b/pass-authz-core/pom.xml
@@ -74,6 +74,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-model</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
@@ -168,4 +168,16 @@ public class AuthUser {
         return user;
     }
 
+    @Override
+    public String toString() {
+        return "AuthUser{" +
+                "name='" + name + '\'' +
+                ", email='" + email + '\'' +
+                ", locatorIds=" + locatorIds +
+                ", id=" + id +
+                ", principal='" + principal + '\'' +
+                ", domains=" + domains +
+                ", user=" + user +
+                '}';
+    }
 }

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUserProvider.java
@@ -42,7 +42,7 @@ public interface AuthUserProvider {
     }
 
     /**
-     * Get the authenticated user, and filter the result before returning. *
+     * Get the authenticated user, and filter the result before returning.
      * <p>
      * Inspects the http request for the current user/principal, and provides information about that user. Invokes the
      * provided function to map/transform/inspect the authenticated user. The primary use case is filter for "create

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -236,6 +236,7 @@
                   <SPRING_ACTIVEMQ_BROKER_URL>failover:(tcp://activemq:61616)?trackMessages=true</SPRING_ACTIVEMQ_BROKER_URL>
                   <SPRING_ACTIVEMQ_USER>messaging</SPRING_ACTIVEMQ_USER>
                   <SPRING_ACTIVEMQ_PASSWORD>moo</SPRING_ACTIVEMQ_PASSWORD>
+                  <FCREPO_LOGBACK_LOCATION>/usr/local/tomcat/lib/logback.xml</FCREPO_LOGBACK_LOCATION>
                 </env>
                 <ports>
                   <port>${FCREPO_PORT}:${FCREPO_PORT}</port>

--- a/pass-authz-integration/pom.xml
+++ b/pass-authz-integration/pom.xml
@@ -224,7 +224,7 @@
                   <FCREPO_HOST>${FCREPO_HOST}</FCREPO_HOST>
                   <FCREPO_PORT>${FCREPO_PORT}</FCREPO_PORT>
                   <FCREPO_JMS_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</FCREPO_JMS_BASEURL>
-                  <PASS_FEDORA_BASEURL>http://localhost:${FCREPO_PORT}/fcrepo/rest/</PASS_FEDORA_BASEURL>
+                  <PASS_FEDORA_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest/</PASS_FEDORA_BASEURL>
                   <PASS_ELASTICSEARCH_URL>http://elasticsearch:9200</PASS_ELASTICSEARCH_URL>
                   <PASS_FEDORA_USER>fedoraAdmin</PASS_FEDORA_USER>
                   <PASS_FEDORA_PASSWORD>moo</PASS_FEDORA_PASSWORD>

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PolicyListenerIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PolicyListenerIT.java
@@ -187,13 +187,13 @@ public class PolicyListenerIT extends FcrepoIT {
         final Grant grant = client.createAndReadResource(g, Grant.class);
 
         // Wait until the submission is successfully created
-        final Submission submission = attempt(10, () -> {
+        final Submission submission = attempt(20, () -> {
             return tryCreateSubmission(user1, grant, SC_CREATED);
         });
 
         // Now try modifying it as somebody else, and assure it fails.
         // Wait until the policy is enacted by the authz listener
-        attempt(10, () -> {
+        attempt(20, () -> {
             tryModifySubmission(user2, submission, SC_FORBIDDEN);
         });
 
@@ -213,13 +213,13 @@ public class PolicyListenerIT extends FcrepoIT {
 
         // Verify that the PI can create a submission, but this time
         // set submitted=true
-        final Submission submission = attempt(10, () -> {
+        final Submission submission = attempt(20, () -> {
             return tryCreateSubmission(user1, grant, SC_CREATED, true);
         });
 
         // Assure we cannot update the submission, since submitted=true and it should be frozen.
         // Wait until the policy is enacted by the authz listener
-        attempt(10, () -> {
+        attempt(20, () -> {
             tryModifySubmission(user1, submission, SC_FORBIDDEN);
         });
 
@@ -236,12 +236,12 @@ public class PolicyListenerIT extends FcrepoIT {
         final Grant grant = client.createAndReadResource(g, Grant.class);
 
         // Create a submission
-        final Submission submission = attempt(10, () -> {
+        final Submission submission = attempt(20, () -> {
             return tryCreateSubmission(user1, grant, SC_CREATED, true);
         });
 
         // Wait until it has an ACL
-        attempt(10, () -> {
+        attempt(20, () -> {
             assertHasACL(submission.getId());
         });
 
@@ -260,12 +260,12 @@ public class PolicyListenerIT extends FcrepoIT {
         final Grant grant = client.createAndReadResource(g, Grant.class);
 
         // Create a submission
-        final Submission submission = attempt(10, () -> {
+        final Submission submission = attempt(20, () -> {
             return tryCreateSubmission(user1, grant, SC_CREATED, false);
         });
 
         // Wait until it has an ACL
-        attempt(10, () -> {
+        attempt(20, () -> {
             assertHasACL(submission.getId());
         });
 
@@ -282,7 +282,7 @@ public class PolicyListenerIT extends FcrepoIT {
         final SubmissionEvent event = client.createAndReadResource(new SubmissionEvent(), SubmissionEvent.class);
 
         // Wait until it has an ACL
-        attempt(10, () -> {
+        attempt(20, () -> {
             assertHasACL(event.getId());
         });
 

--- a/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PolicyListenerIT.java
+++ b/pass-authz-integration/src/test/java/org/dataconservancy/pass/authz/PolicyListenerIT.java
@@ -110,7 +110,8 @@ public class PolicyListenerIT extends FcrepoIT {
                 .withEnv("PASS_AUTHZ_QUEUE", System.getProperty("pass.authz.queue"))
                 .withEnv("JMS_USERNAME", System.getProperty("jms.username"))
                 .withEnv("JMS_PASSWORD", System.getProperty("jms.password"))
-                .withEnv("LOG.org.dataconservancy.pass.authz", "DEBUG")
+                .withEnv("LOG.org.dataconservancy.pass.authz", "TRACE")
+                .withEnv("LOG.org.dataconservancy.pass", "DEBUG")
                 .onOutputLine(s -> {
                     if (s.contains("Listening")) {
                         ready.set(true);

--- a/pass-authz-integration/src/test/resources/docker/Dockerfile
+++ b/pass-authz-integration/src/test/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oapass/fcrepo:4.7.5-3.1-SNAPSHOT
+FROM oapass/fcrepo:4.7.5-3.2-3
 
 RUN rm -rf /usr/local/tomcat/webapps/pass-user-service && \
     rm /usr/local/tomcat/lib/pass-authz* && \

--- a/pass-authz-integration/src/test/resources/docker/Dockerfile
+++ b/pass-authz-integration/src/test/resources/docker/Dockerfile
@@ -10,3 +10,4 @@ COPY pass-user-service.war /usr/local/tomcat/webapps/
 COPY pass-authz-roles.jar /usr/local/tomcat/lib
 COPY pass-authz-core-shaded.jar /usr/local/tomcat/lib
 COPY fcrepo.xml /usr/local/tomcat/conf/Catalina/localhost/
+COPY logback.xml /usr/local/tomcat/lib

--- a/pass-authz-integration/src/test/resources/docker/logback.xml
+++ b/pass-authz-integration/src/test/resources/docker/logback.xml
@@ -1,0 +1,34 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%20.20thread] %-5level [%30.-30C{0}] - %msg%n
+            </pattern>
+        </encoder>
+        <target>System.err</target>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="STDERR"/>
+    </root>
+    <logger name="org.springframework" additivity="false" level="WARN">
+        <appender-ref ref="STDERR"/>
+    </logger>
+    <logger name="org.fcrepo.client" additivity="false" level="WARN">
+        <appender-ref ref="STDERR"/>
+    </logger>
+    <logger name="org.dataconservancy.pass" additivity="false" level="DEBUG">
+        <appender-ref ref="STDERR"/>
+    </logger>
+    <logger name="org.dataconservancy.pass.authz" additivity="false" level="TRACE">
+        <appender-ref ref="STDERR"/>
+    </logger>
+
+    <logger name="org.elasticsearch" additivity="false" level="WARN">
+        <appender-ref ref="STDERR"/>
+    </logger>
+
+    <!-- the rest client is noisy, and detracts from looking at test logging output -->
+    <logger name="org.elasticsearch.client.RestClient" additivity="false" level="ERROR">
+        <appender-ref ref="STDERR"/>
+    </logger>
+</configuration>

--- a/pass-authz-roles/src/main/java/org/dataconservancy/pass/authz/roles/AuthRolesProvider.java
+++ b/pass-authz-roles/src/main/java/org/dataconservancy/pass/authz/roles/AuthRolesProvider.java
@@ -81,9 +81,10 @@ public abstract class AuthRolesProvider {
             }
         }
 
-        LOG.debug("Found roles for {}: {}", authUser.getPrincipal(), roles);
 
         roles.addAll(addFedoraHack(authUser.getUser().getId()));
+
+        LOG.debug("Found roles for {}: {}", authUser.getPrincipal(), roles);
 
         return roles;
     }

--- a/pass-authz-roles/src/main/java/org/dataconservancy/pass/authz/roles/PassRolesFilter.java
+++ b/pass-authz-roles/src/main/java/org/dataconservancy/pass/authz/roles/PassRolesFilter.java
@@ -177,6 +177,7 @@ public class PassRolesFilter implements Filter {
                             if (a.getId() != null && a.getUser() == null) {
                                 a.setUser(passClient.readResource(a.getId(), User.class));
                             }
+                            LOG.debug("Exiting critical section");
                             return a;
                         }, true);
 

--- a/pass-user-service/pom.xml
+++ b/pass-user-service/pom.xml
@@ -49,6 +49,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-client-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-model</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
@@ -57,6 +69,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dataconservancy.pass.support.messaging</groupId>
+      <artifactId>cri</artifactId>
     </dependency>
 
     <dependency>

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/TokenService.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/TokenService.java
@@ -23,6 +23,9 @@ import static org.dataconservancy.pass.authz.usertoken.Key.USER_TOKEN_KEY_PROPER
 import static org.dataconservancy.pass.client.util.ConfigUtil.getSystemProperty;
 
 import java.net.URI;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.dataconservancy.pass.authz.acl.ACLManager;
 import org.dataconservancy.pass.authz.usertoken.BadTokenException;
@@ -32,7 +35,10 @@ import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.client.PassClientFactory;
 import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.User;
-
+import org.dataconservancy.pass.support.messaging.cri.CriticalPath;
+import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction.CriticalResult;
+import org.dataconservancy.pass.support.messaging.cri.DefaultConflictHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,15 +55,25 @@ class TokenService {
 
     static final Logger LOG = LoggerFactory.getLogger(TokenService.class);
 
+    CriticalRepositoryInteraction cri;
+
     public TokenService() {
         tokenFactory = ofNullable(getSystemProperty(USER_TOKEN_KEY_PROPERTY, null)).map(TokenFactory::new).orElse(
                 null);
         client = PassClientFactory.getPassClient();
+        cri = new CriticalPath(client, new DefaultConflictHandler(client));
     }
 
     public TokenService(TokenFactory factory, PassClient client) {
         this.tokenFactory = factory;
         this.client = client;
+        cri = new CriticalPath(client, new DefaultConflictHandler(client));
+    }
+
+    public TokenService(TokenFactory tokenFactory, PassClient client, CriticalRepositoryInteraction cri) {
+        this.tokenFactory = tokenFactory;
+        this.client = client;
+        this.cri = cri;
     }
 
     Token fromQueryString(String token) {
@@ -93,54 +109,143 @@ class TokenService {
             throw new NullPointerException("Cannot process token for a null or unidentified user");
         }
 
-        final Submission submission;
-        try {
-            submission = client.readResource(token.getPassResource(), Submission.class);
+        final CriticalResult<Submission, Submission> cr = cri.performCritical(token.getPassResource(), Submission.class,
+                preconditions(user, token),
+                postConditions(user),
+                criticalSection(user));
 
-            if (submission == null) {
-                throw new RuntimeException(String.format("Submission <%s> not found", token.getPassResource()));
-            }
-        } catch (final Exception e) {
-            LOG.warn(format("Failed reading submission <%s>, cannot further process user token given by user <%s>",
-                    token.getPassResource(), user.getId()), e);
-            throw new BadTokenException(format("The submission <%s> is no longer accessible", token
-                    .getPassResource()), e);
-        }
-
-        if (token.getReference().equals(submission.getSubmitterEmail())) {
-            LOG.info("User <{}> will be made a submitter for <{}>, based on matching e-mail <{}>",
-                    user.getId(),
-                    submission.getId(),
-                    submission.getSubmitterEmail());
-
-            submission.setSubmitterEmail(null);
-            submission.setSubmitterName(null);
-
-            if (submission.getSubmitter() != null && !submission.getSubmitter().equals(token.getReference()) &&
-                    !submission.getSubmitter().equals(user.getId())) {
-                throw new BadTokenException(format(
-                        "There is already a submitter <%s> for the submission <%s>, and it isn't the intended user <%s>  Refusing to apply the token for <%s>",
-                        submission.getSubmitter(), submission.getId(), user.getId(), token.getReference()));
+        if (!cr.success()) {
+            if (!cr.resource().isPresent()) {
+                LOG.warn("Submission <{}> not found", token.getPassResource());
+                LOG.warn(format("Failed reading submission <%s>, cannot further process user token given by user <%s>",
+                        token.getPassResource(), user.getId()));
+                throw new BadTokenException(format("The submission <%s> is no longer accessible", token
+                        .getPassResource()));
             }
 
-            submission.setSubmitter(user.getId());
-            client.updateResource(submission);
-            return true;
-
-        } else if (user.getId().equals(submission.getSubmitter())) {
-            LOG.info("User <{}> already in place as the submitter.  Ignoring user token");
+            throwIfPresent(cr, null);
             return false;
-        } else {
-            final String message = format(
-                    "New user token does not match expected e-mail <%s> on submission <%s>; found <%s> instead",
-                    token.getReference(), submission.getId(), submission.getSubmitterEmail());
-
-            LOG.warn(message);
-            throw new BadTokenException(message);
         }
+
+        return true;
     }
 
     public void addWritePermissions(User user, Token token) {
         acls.addPermissions(token.getPassResource()).grantWrite(asList(user.getId())).perform();
+    }
+
+    /**
+     * Answers a {@code Function} that associates the {@code User} with the {@code Submission} as
+     * {@code Submission.submitter}, and nulls out {@code Submission.submitterEmail} and
+     * {@code Submission.submitterName}.
+     *
+     * @param user the {@code User} presenting the token
+     * @return a {@code Function} associating the supplied {@code User} with the {@code Submission}
+     */
+    static Function<Submission, Submission> criticalSection(User user) {
+        return (criSubmission) -> {
+            criSubmission.setSubmitterEmail(null);
+            criSubmission.setSubmitterName(null);
+            criSubmission.setSubmitter(user.getId());
+            return criSubmission;
+        };
+    }
+
+    /**
+     * Answers a {@code Predicate&lt;Submission&gt;} that insures:
+     * <ul>
+     *     <li>{@code Submission.submitterEmail} is {@code null}</li>
+     *     <li>{@code Submission.submitterName} is {@code null}</li>
+     *     <li>{@code Submission.submitter} references the supplied {@code User}</li>
+     * </ul>
+     *
+     * If all postconditions are met, the {@code Predicate} returns {@code true}, otherwise {@code false}.
+     *
+     *
+     * @param user the {@code User} associated with the {@code Submission}
+     * @return the {@code Predicate} providing post-conditions insuring the {@code User} was properly applied to the
+     *         {@code Submission}
+     */
+    static Predicate<Submission> postConditions(User user) {
+        return (criSubmission) -> {
+            if (criSubmission.getSubmitterEmail() == null &&
+                    criSubmission.getSubmitterName() == null &&
+                    criSubmission.getSubmitter().equals(user.getId())) {
+
+                LOG.info("User <{}> made a submitter for <{}>, based on matching e-mail <{}>",
+                        user.getId(),
+                        criSubmission.getId(),
+                        criSubmission.getSubmitterEmail());
+                return true;
+            }
+
+            return false;
+        };
+    }
+
+    /**
+     * Answers a {@code Predicate&lt;Submission&gt;} that insures:
+     * <ul>
+     *     <li>The token reference equals the {@code Submission.submitterEmail}</li>
+     *     <li>An existing {@code Submission.submitter} is the same {@code User} referenced by the token</li>
+     * </ul>
+     *
+     * If all preconditions are met, the {@code Predicate} returns {@code true}.
+     *
+     * If the {@code User} is already associated with the {@code Submission} as the {@code Submission.submitter},
+     * the {@code Predicate} returns {@code false}, because applying the critical section (associating the {@code User}
+     * to the {@code Submission}) would be redundant.
+     *
+     * If any preconditions fail, the {@code Predicate} returns {@code false}.
+     *
+     * @param user the {@code User} presenting the token to be associated with the {@code Submission}
+     * @param token the token
+     * @return the {@code Predicate} providing pre-conditions for associating the {@code User} with a {@code Submission}
+     */
+    static Predicate<Submission> preconditions(User user, Token token) {
+        return (s) -> {
+            if (token.getReference().equals(s.getSubmitterEmail())) {
+                if (s.getSubmitter() != null && !s.getSubmitter().equals(token.getReference()) &&
+                        !s.getSubmitter().equals(user.getId())) {
+                    throw new BadTokenException(format(
+                            "There is already a submitter <%s> for the criSubmission <%s>, and it isn't the intended " +
+                                    "user <%s>  Refusing to apply the token for <%s>",
+                            s.getSubmitter(), s.getId(), user.getId(), token.getReference()));
+                }
+
+                return true;
+            } else if (user.getId().equals(s.getSubmitter())) {
+                LOG.info("User <{}> already in place as the submitter.  Ignoring user token", user.getId());
+                return false;
+            } else {
+                final String message = format(
+                        "New user token does not match expected e-mail <%s> on criSubmission <%s>; found <%s> instead",
+                        token.getReference(), s.getId(), s.getSubmitterEmail());
+
+                LOG.warn(message);
+                throw new BadTokenException(message);
+            }
+        };
+    }
+
+    /**
+     * Throw the exception present in the {@code CriticalResult} as a {@code RuntimeException}.  Wraps the underlying
+     * {@code Throwable} if necessary.  If a {@code Throwable} isn't present, throw the {@code RuntimeException}
+     * supplied by the non-null {@code Supplier&lt;RuntimeException&gt;}
+     *
+     * @param cr a {@code CriticalResult} that may contain a {@code Throwable}
+     * @param orElse a {@code Supplier} of {@code RuntimeException} that may be thrown if the {@code CriticalResult}
+     *               {@code Throwable} isn't present.  May be {@code null}.
+     */
+    private static void throwIfPresent(CriticalResult<Submission, Submission> cr, Supplier<RuntimeException> orElse) {
+        if (cr.throwable().isPresent()) {
+            if (cr.throwable().get() instanceof RuntimeException) {
+                throw (RuntimeException) cr.throwable().get();
+            } else {
+                throw new RuntimeException(cr.throwable().get());
+            }
+        } else if (orElse != null) {
+            throw orElse.get();
+        }
     }
 }

--- a/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
+++ b/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -210,6 +212,8 @@ public class UserServletTest {
         found.setLocatorIds(USER.getLocatorIds());
         found.setRoles(Arrays.asList(Role.ADMIN));
         when(client.readResource(eq(foundId), eq(User.class))).thenReturn(found);
+        when(client.updateAndReadResource(argThat(u -> u.getId().equals(foundId)), eq(User.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
 
         servlet.doGet(request, response);
 
@@ -223,7 +227,10 @@ public class UserServletTest {
         assertTrue(fromServlet.getLocatorIds().containsAll(USER.getLocatorIds()));
         assertEquals(USER.getLocatorIds().size(), fromServlet.getLocatorIds().size());
 
-        verify(client).updateResource((userCaptor.capture()));
+        verify(client).readResource(eq(foundId), eq(User.class));
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(client).updateAndReadResource(userCaptor.capture(), eq(User.class));
+        assertEquals(foundId, userCaptor.getValue().getId());
 
         final User updated = userCaptor.getValue();
         assertEquals(USER.getName(), updated.getDisplayName());

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <system.rules.version>1.18.0</system.rules.version>
     <powermock.version>2.0.0-RC.1</powermock.version>
     <json.version>20180130</json.version>
+    <messaging-support.version>0.1.1-3.2</messaging-support.version>
 
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.27.2</docker-maven-plugin.version>
@@ -280,6 +281,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.dataconservancy.pass</groupId>
+        <artifactId>pass-client-api</artifactId>
+        <version>${pass.fedora.client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.dataconservancy.pass</groupId>
+        <artifactId>pass-model</artifactId>
+        <version>${pass.fedora.client.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet.version}</version>
@@ -399,6 +412,12 @@
         <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.dataconservancy.pass.support.messaging</groupId>
+        <artifactId>cri</artifactId>
+        <version>${messaging-support.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
## About

Addresses concurrency issues with new user creation, evidenced when an individual activates an invite link from an email notification that contains a user token.  Previous PRs addressed currency issues related to new user creation, but when user tokens were introduced (manifest as query parameters on request to the pass-user-service) as a part of the new-user invite mechanism, a bug surfaced that results in multiple `User` resources being created for a single Shibboleth login.

Having multiple `User` resources is a no-no - with high-impact, user-visible, consequences - and should be avoided; users of the Ember UI will be presented with errors, and access to the user's submissions will be affected.

The PASS UI issues multiple requests to the pass-user-service when a Shibboleth-authenticated person logs in after activating an invite link with a user token.  When Ember issues a request to the pass-user-service, some of those requests append the user token, other requests do not.  There really is no reasoning about Ember's behavior; in order to be robust, the pass-user-service needs to gracefully handle concurrent requests, some with tokens, some without.

## Bug

The root cause of the bug is that acting on a user token present in a request was not safe from a concurrency aspect.  It was possible for two separate threads to operate on the same Shibboleth user's token activation request, resulting in the creation of multiple `User` resources, by setting the `forceGenerate` flag to `true` when interacting with the cache.

## Fix

There's lots of different ways to fix this issue, some are more correct than others.  See another approach in #78.

The approach in this PR is to remove the `forceGenerate` flag, and _always_ execute the `doAfter` filter (taking the form of `Function<AuthUser, AuthUser>` in this PR), on both cache hits, and on misses (when cache values are generated).

One downside is that this PR leaves the update or creation of `User` resources coupled to token application in `UserServlet`.  An upside is that this PR results in minimal changes to test code.

## Secondary issues

When testing this fix, it became clear that the `TokenService` needed to be updated to re-try requests in the face of `UpdateConflictException`s when modifying `Submission` resources.  This deserves a PR of its own, but because the concurrency fix for the root issue immediately unveils the issue with `TokenService`, they're all together in this PR.  The fix for `TokenService` uses the `CriticalRepositoryInteraction` class to isolate the pre-conditions, post-conditions, and critical path, and comes with a built-in retry mechanism.  Unit tests and ITs were updated to insure `TokenService` is working as it should.

