### PR TITLE
Move token logic outside of the user generator

### DIFF
--- a/pass-authz-integration/src/test/resources/docker/Dockerfile
+++ b/pass-authz-integration/src/test/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oapass/fcrepo:4.7.5-3.1-SNAPSHOT
+FROM oapass/fcrepo:4.7.5-3.2-3
 
 RUN rm -rf /usr/local/tomcat/webapps/pass-user-service && \
     rm /usr/local/tomcat/lib/pass-authz* && \

--- a/pass-authz-usertoken/src/main/java/org/dataconservancy/pass/authz/usertoken/Token.java
+++ b/pass-authz-usertoken/src/main/java/org/dataconservancy/pass/authz/usertoken/Token.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 /**
  * User token; encodes the identity of a PASS resource, and a reference/link within it.
@@ -141,5 +142,23 @@ public class Token {
             // Should never happen
             throw new RuntimeException("Gosh, your platform does not support UTF-8??");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Token that = (Token) o;
+        return Objects.equals(resource, that.resource) &&
+                Objects.equals(reference, that.reference);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resource, reference);
     }
 }


### PR DESCRIPTION
Tokens are used for enacting permissions changes to submissions, and have nothing to do with creating or updating users.  This conflation lead to the incorrect solution of invalidating the cache in order to
enact a token.  

Instead, this PR explores separating out the token logic, and protecting it by its own cache so that each token is only enacted once in the face of concurrent requests
