### PR TITLE
Include first and last name when creating or updating User resources

### DIFF
--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
@@ -32,6 +32,10 @@ public class AuthUser {
 
     private String name;
 
+    private String givenName;
+
+    private String surname;
+
     private String email;
 
     private List<String> locatorIds = new ArrayList<>();
@@ -114,6 +118,46 @@ public class AuthUser {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Get the given name for the user, as determined by the authentication provider.  Differs from the display name
+     * as the given name is typically the user's first name.
+     *
+     * @return the given name
+     */
+    public String getGivenName() {
+        return givenName;
+    }
+
+    /**
+     * Set the given name for the user, as determined by the authentication provider. Differs from the display name
+     * as the given name is typically the user's first name.
+     *
+     * @param givenName the given name
+     */
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    /**
+     * Get the surname for the user, as determined by the authentication provider. Differs from the display name
+     * as the surname is only the user's last name.
+     *
+     * @return the surname
+     */
+    public String getSurname() {
+        return surname;
+    }
+
+    /**
+     * Set the surname for the user, as determined by the authentication provider. Differs from the display name
+     * as the surname is only the user's last name.
+     *
+     * @param surname the surname
+     */
+    public void setSurname(String surname) {
+        this.surname = surname;
     }
 
     /**

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
  * Implementation of the AuthUserProvider interface for JHU's Shibboleth service We are interested in six headers
  * <ul>
  * <li>Displayname - First Last</li>
+ * <li>Givenname - First</li>
+ * <li>Sn - Last</li>
  * <li>Mail - the user's preferred email address</li>
  * <li>Eppn - the user's "official" JHU email address, which starts with the users institutional id</li>
  * <li>Affiliation - a semi-colon-separated list of roles or statuses indicating employment type and domain</li>
@@ -72,6 +74,10 @@ public class ShibAuthUserProvider implements AuthUserProvider {
 
     /** EPPN http header */
     public static final String EPPN_HEADER = "Eppn";
+
+    public static final String GIVENNAME_HEADER = "Givenname";
+
+    public static final String SN_HEADER = "Sn";
 
     /** Scoped affiliation http header */
     public static final String SCOPED_AFFILIATION_HEADER = "Affiliation";
@@ -143,6 +149,8 @@ public class ShibAuthUserProvider implements AuthUserProvider {
         }
 
         final String displayName = getShibAttr(request, DISPLAY_NAME_HEADER, String::trim);
+        final String givenName = getShibAttr(request, GIVENNAME_HEADER, String::trim);
+        final String surname = getShibAttr(request, SN_HEADER, String::trim);
         final String emailAddress = getShibAttr(request, EMAIL_HEADER, String::trim);
         final String domain = getShibAttr(request, EPPN_HEADER, s -> s.split("@")[1]);
         String institutionalId = getShibAttr(request, EPPN_HEADER, s -> s.split("@")[0]);
@@ -159,6 +167,8 @@ public class ShibAuthUserProvider implements AuthUserProvider {
 
         final AuthUser authUser = new AuthUser();
         authUser.setName(displayName);
+        authUser.setGivenName(givenName);
+        authUser.setSurname(surname);
         authUser.setEmail(emailAddress);
         // populate the locatorId list with durable ids first - shib user always has hopkins id
         if (hopkinsId != null) {

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -171,6 +171,8 @@ public class UserServlet extends HttpServlet {
         user.setUsername(authUser.getPrincipal());
         user.setLocatorIds(authUser.getLocatorIds());
         user.setDisplayName(authUser.getName());
+        user.setFirstName(authUser.getGivenName());
+        user.setLastName(authUser.getSurname());
         user.setEmail(authUser.getEmail());
         user.getRoles().add(User.Role.SUBMITTER);
 
@@ -205,6 +207,16 @@ public class UserServlet extends HttpServlet {
         }
         if (user.getDisplayName() == null || !user.getDisplayName().equals(shibUser.getName())) {
             user.setDisplayName(shibUser.getName());
+            update = true;
+        }
+
+        if (user.getFirstName() == null || !user.getFirstName().equals(shibUser.getGivenName())) {
+            user.setFirstName(shibUser.getGivenName());
+            update = true;
+        }
+
+        if (user.getLastName() == null || !user.getLastName().equals(shibUser.getSurname())) {
+            user.setLastName(shibUser.getSurname());
             update = true;
         }
 

--- a/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
+++ b/pass-user-service/src/test/java/org/dataconservancy/pass/authz/service/user/UserServletTest.java
@@ -111,6 +111,8 @@ public class UserServletTest {
         USER.setPrincipal("bessie@farm.com");
         USER.setName("MOOO COW");
         USER.setEmail("bessie@farm.com");
+        USER.setGivenName("MOOO");
+        USER.setSurname("COW");
         USER.getLocatorIds().add(new Identifier(domain, JHED_ID_TYPE, "cowb1").serialize());
         USER.getLocatorIds().add(new Identifier(domain, EMPLOYEE_ID_TYPE, "08675309").serialize());
         USER.getLocatorIds().add(new Identifier(domain, EMPLOYEE_ID_TYPE, "P2P2P2").serialize());
@@ -119,6 +121,8 @@ public class UserServletTest {
         user.setId(URI.create("http://example.org:2020/" + UUID.randomUUID().toString()));
         user.setUsername(USER.getPrincipal());
         user.setDisplayName(USER.getName());
+        user.setFirstName(USER.getGivenName());
+        user.setLastName(USER.getSurname());
         user.setEmail(USER.getEmail());
         user.setLocatorIds(USER.getLocatorIds());
         user.setRoles(Arrays.asList(Role.ADMIN));
@@ -180,6 +184,8 @@ public class UserServletTest {
 
         assertEquals(newUserId, fromServlet.getId());
         assertEquals(USER.getName(), fromServlet.getDisplayName());
+        assertEquals(USER.getGivenName(), fromServlet.getFirstName());
+        assertEquals(USER.getSurname(), fromServlet.getLastName());
         assertEquals(USER.getEmail(), fromServlet.getEmail());
         assertTrue(USER.getLocatorIds().containsAll(fromServlet.getLocatorIds()));
         assertTrue(fromServlet.getLocatorIds().containsAll(USER.getLocatorIds()));
@@ -218,6 +224,8 @@ public class UserServletTest {
 
         assertEquals(foundId, fromServlet.getId());
         assertEquals(USER.getName(), fromServlet.getDisplayName());
+        assertEquals(USER.getGivenName(), fromServlet.getFirstName());
+        assertEquals(USER.getSurname(), fromServlet.getLastName());
         assertEquals(USER.getEmail(), fromServlet.getEmail());
         assertTrue(USER.getLocatorIds().containsAll(fromServlet.getLocatorIds()));
         assertTrue(fromServlet.getLocatorIds().containsAll(USER.getLocatorIds()));
@@ -228,6 +236,8 @@ public class UserServletTest {
         final User updated = userCaptor.getValue();
         assertEquals(USER.getName(), updated.getDisplayName());
         assertEquals(USER.getEmail(), updated.getEmail());
+        assertEquals(USER.getGivenName(), fromServlet.getFirstName());
+        assertEquals(USER.getSurname(), fromServlet.getLastName());
         assertEquals(Arrays.asList(Role.ADMIN), updated.getRoles());
         assertTrue(USER.getLocatorIds().containsAll(updated.getLocatorIds()));
         assertTrue(updated.getLocatorIds().containsAll(USER.getLocatorIds()));
@@ -247,6 +257,8 @@ public class UserServletTest {
 
         assertEquals(USER.getUser().getId(), fromServlet.getId());
         assertEquals(USER.getName(), fromServlet.getDisplayName());
+        assertEquals(USER.getGivenName(), fromServlet.getFirstName());
+        assertEquals(USER.getSurname(), fromServlet.getLastName());
         assertEquals(USER.getEmail(), fromServlet.getEmail());
         assertTrue(USER.getLocatorIds().containsAll(fromServlet.getLocatorIds()));
         assertTrue(fromServlet.getLocatorIds().containsAll(USER.getLocatorIds()));
@@ -270,6 +282,8 @@ public class UserServletTest {
         found.setId(foundId);
         found.setUsername(USER.getPrincipal());
         found.setDisplayName(USER.getName());
+        found.setFirstName(USER.getGivenName());
+        found.setLastName(USER.getSurname());
         found.setEmail(USER.getEmail());
         found.setLocatorIds(USER.getLocatorIds());
         found.setRoles(Arrays.asList(Role.ADMIN));
@@ -283,6 +297,8 @@ public class UserServletTest {
         assertNotEquals(foundId, fromServlet.getId());
         assertTrue(fromServlet.getId().toString().contains("https"));
         assertEquals(USER.getName(), fromServlet.getDisplayName());
+        assertEquals(USER.getGivenName(), fromServlet.getFirstName());
+        assertEquals(USER.getSurname(), fromServlet.getLastName());
         assertEquals(USER.getEmail(), fromServlet.getEmail());
         assertTrue(USER.getLocatorIds().containsAll(fromServlet.getLocatorIds()));
         assertTrue(fromServlet.getLocatorIds().containsAll(USER.getLocatorIds()));


### PR DESCRIPTION
Update pass-user-service to include given name and surname when creating or updating User resources

- Add ShibAuthUser support for reading the Shibboleth headers 'Givenname' and 'Surname' respectively
- Add givenName and surname as fields on AuthUser
- Update UserServlet to set User.firstName and User.lastName from the AuthUser.givenName and AuthUser.surname
- Update tests