### PR TITLE
Update pass-authz-tools to use an externally-defined role base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: true
 script:

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ Configuration:
 
 * Standard PASS java client [properties](https://github.com/OA-PASS/java-fedora-client#configuration) for Fedora username,  password, and baseURI.
 * `TYPE` (or, as a java property, `-Dtype`).  For the individual permissions updator, this specifies the type of PASS entity to update.  If not specified, it will update all.
+* `PASS_AUTHZ_ROLEBASE` (or as, a java property, `-Dpass.authz.rolebase`).  Example value: `http://oapass.org/ns/roles/johnshopkins.edu`.  Specifies the base URI used when setting [authorization roles](#authorization-roles).  For the container permissions updator, overrides the value set in `containers.yml`.
+
 
 For example:
 
-    java -Dpass.fedora.baseurl=http://example.org/fcrepo/rest -Dtype=SubmissionEvent -Dpass.fedora.user=fedoraAdmin -Dpass.fedora.password=pass -jar pass-authz-tools-${version}-SNAPSHOT-individual-permissions-exe.jar
+    java -Dpass.fedora.baseurl=http://example.org/fcrepo/rest -Dpass.authz.rolebase=http://oapass.org/ns/roles/harvard.edu -Dtype=SubmissionEvent -Dpass.fedora.user=fedoraAdmin -Dpass.fedora.password=pass -jar pass-authz-tools-${version}-SNAPSHOT-individual-permissions-exe.jar
     
 ### pass-authz-usertoken
 

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/Const.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/Const.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.authz.tools.main;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+class Const {
+
+    /**
+     * Base URI for PASS roles, e.g. {@code http://oapass.org/ns/roles/johnshopkins.edu}
+     */
+    static final String ROLE_BASE = "pass.authz.rolebase";
+
+}

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/Const.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/Const.java
@@ -15,14 +15,27 @@
  */
 package org.dataconservancy.pass.authz.tools.main;
 
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
 class Const {
 
     /**
-     * Base URI for PASS roles, e.g. {@code http://oapass.org/ns/roles/johnshopkins.edu}
+     * Property or environment varialbe containing the base URI for PASS roles, e.g.
+     * {@code http://oapass.org/ns/roles/johnshopkins.edu}
      */
-    static final String ROLE_BASE = "pass.authz.rolebase";
+    static final String ROLE_BASE_PROP = "pass.authz.rolebase";
 
+    /**
+     * Optional base URI provided by {@link #ROLE_BASE_PROP}
+     */
+    static final Optional<URI> ROLE_BASE_URI = ofNullable(System.getProperties().getProperty(Const.ROLE_BASE_PROP,
+            System.getenv(Const.ROLE_BASE_PROP.toUpperCase().replace(".", "_"))))
+            .map(uri -> uri.endsWith("#") ? uri : uri + "#")
+            .map(URI::create);
 }

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/ContainerPermissions.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/ContainerPermissions.java
@@ -63,7 +63,11 @@ public class ContainerPermissions {
         final FcrepoClient client = getFcrepoClient();
 
         containerBase = URI.create(ofNullable(FedoraConfig.getBaseUrl()).orElse(root.get("container-base").asText()));
-        roleBase = ofNullable(root.get("role-base").asText()).map(URI::create).orElse(null);
+        roleBase = ofNullable(System.getProperties().getProperty(Const.ROLE_BASE,
+                    System.getenv(Const.ROLE_BASE.toUpperCase().replace(".", "_"))))
+                .map(uri -> uri.endsWith("#") ? uri : uri + "#")
+                .map(URI::create)
+                .orElse(URI.create(root.get("role-base").asText()));
 
         try (FcrepoResponse response = client.head(getAclBase()).perform()) {
             if (response.getStatusCode() == 404) {

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/ContainerPermissions.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/ContainerPermissions.java
@@ -19,6 +19,7 @@ package org.dataconservancy.pass.authz.tools.main;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.ofNullable;
 import static org.dataconservancy.pass.authz.acl.ACLManager.getAclBase;
+import static org.dataconservancy.pass.authz.tools.main.Const.ROLE_BASE_URI;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -63,11 +64,7 @@ public class ContainerPermissions {
         final FcrepoClient client = getFcrepoClient();
 
         containerBase = URI.create(ofNullable(FedoraConfig.getBaseUrl()).orElse(root.get("container-base").asText()));
-        roleBase = ofNullable(System.getProperties().getProperty(Const.ROLE_BASE,
-                    System.getenv(Const.ROLE_BASE.toUpperCase().replace(".", "_"))))
-                .map(uri -> uri.endsWith("#") ? uri : uri + "#")
-                .map(URI::create)
-                .orElse(URI.create(root.get("role-base").asText()));
+        roleBase = ROLE_BASE_URI.orElse(URI.create(root.get("role-base").asText()));
 
         try (FcrepoResponse response = client.head(getAclBase()).perform()) {
             if (response.getStatusCode() == 404) {

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
@@ -32,16 +32,24 @@ import org.dataconservancy.pass.model.SubmissionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * @author apb@jhu.edu
  */
 public class PermissionsUpdater {
 
-    static final URI PASS_BACKEND_ROLE = URI.create("http://oapass.org/ns/roles/johnshopkins.edu#pass-backend");
+    static final URI ROLE_BASE = ofNullable(System.getProperties().getProperty(Const.ROLE_BASE,
+            System.getenv(Const.ROLE_BASE.toUpperCase().replace(".", "_"))))
+            .map(uri -> uri.endsWith("#") ? uri : uri + "#")
+            .map(URI::create)
+            .orElse(URI.create("http://oapass.org/ns/roles/johnshopkins.edu#"));
 
-    static final URI PASS_GRANTADMIN_ROLE = URI.create("http://oapass.org/ns/roles/johnshopkins.edu#admin");
+    static final URI PASS_BACKEND_ROLE = URI.create(ROLE_BASE.toString() + "pass-backend");
 
-    static final URI PASS_SUBMITTER_ROLE = URI.create("http://oapass.org/ns/roles/johnshopkins.edu#submitter");
+    static final URI PASS_GRANTADMIN_ROLE = URI.create(ROLE_BASE.toString() + "admin");
+
+    static final URI PASS_SUBMITTER_ROLE = URI.create(ROLE_BASE.toString() + "submitter");
 
     static final Logger LOG = LoggerFactory.getLogger(PermissionsUpdater.class);
 

--- a/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
+++ b/pass-authz-tools/src/main/java/org/dataconservancy/pass/authz/tools/main/PermissionsUpdater.java
@@ -32,18 +32,14 @@ import org.dataconservancy.pass.model.SubmissionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.Optional.ofNullable;
+import static org.dataconservancy.pass.authz.tools.main.Const.ROLE_BASE_URI;
 
 /**
  * @author apb@jhu.edu
  */
 public class PermissionsUpdater {
 
-    static final URI ROLE_BASE = ofNullable(System.getProperties().getProperty(Const.ROLE_BASE,
-            System.getenv(Const.ROLE_BASE.toUpperCase().replace(".", "_"))))
-            .map(uri -> uri.endsWith("#") ? uri : uri + "#")
-            .map(URI::create)
-            .orElse(URI.create("http://oapass.org/ns/roles/johnshopkins.edu#"));
+    static final URI ROLE_BASE = ROLE_BASE_URI.orElse(URI.create("http://oapass.org/ns/roles/johnshopkins.edu#"));
 
     static final URI PASS_BACKEND_ROLE = URI.create(ROLE_BASE.toString() + "pass-backend");
 


### PR DESCRIPTION
Allow for the base URI for roles to be set via a system property or env var (`pass.authz.rolebase`, `PASS_AUTHZ_ROLEBASE`) when updating container or resource ACLs using `pass-authz-tools`.