### PR TITLE
Remove hopkins-isms from the locator id types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: true
 script:

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -92,10 +92,10 @@ public class ShibAuthUserProvider implements AuthUserProvider {
     public static final String EMPLOYEE_ID_TYPE = "employeeid";
 
     /** hopkins id identifier type */
-    public static final String HOPKINS_ID_TYPE = "hopkinsid";
+    public static final String HOPKINS_ID_TYPE = "unique-id";
 
     /** JHED id type */
-    public static final String JHED_ID_TYPE = "jhed";
+    public static final String JHED_ID_TYPE = "eppn";
 
     final PassClient passClient;
 


### PR DESCRIPTION
Replaces `hopkinsid` identifier type with `unique-id`.  Replaces `jhed` identifier type with `eppn`.

Users will get created with locator ids that no longer have types that refer to hopkins, e.g.:
```json
{
  "@type" : "User",
  "username" : "incomplete-nih-user@harvard.edu",
  "firstName" : "Incomplete",
  "middleName" : null,
  "lastName" : "Nihuser",
  "displayName" : "Incomplete Nihuser",
  "email" : "incompletenihuser@harvard.edu",
  "affiliation" : null,
  "locatorIds" : [ "harvard.edu:eppn:incomplete-nih-user", "harvard.edu:employeeid:00023666", "harvard.edu:unique-id:SDH72F" ],
  "orcidId" : null,
  "roles" : [ "submitter" ],
  "@id" : "https://pass.local/fcrepo/rest/users/2e/67/a3/cb/2e67a3cb-1200-497b-ba0e-2c91a5d562a7",
  "@context" : "https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld"
}
```
If JHU PASS is updated to include this PR in `pass-authz-core`, existing `User`s that lack an employeeid locator id will have to be found, and have their remaining legacy locatorids (the ones using `hopkinsid` and `jhed`) updated to use `unique-id` and `eppn`.

