### PR TITLE
WIP: Capture and store User affiliation

### DIFF
--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/AuthUser.java
@@ -46,6 +46,8 @@ public class AuthUser {
 
     private final Set<String> domains = new HashSet<>();
 
+    private Set<String> scopedAffiliations = new HashSet<>();
+
     private User user;
 
     /**
@@ -212,4 +214,21 @@ public class AuthUser {
         return user;
     }
 
+    /**
+     * The affiliation(s) of the user, per domain.  Typically in the form {@code &lt;affiliation&gt;@&lt;domain&gt;}
+     *
+     * @return the user's affiliation(s)
+     */
+    public Set<String> getScopedAffiliations() {
+        return scopedAffiliations;
+    }
+
+    /**
+     * The affiliation(s) of the user, per domain.  Typically in the form {@code &lt;affiliation&gt;@&lt;domain&gt;}
+     *
+     * @param scopedAffiliations the user's affiliation(s) for each domain
+     */
+    public void setScopedAffiliations(Set<String> scopedAffiliations) {
+        this.scopedAffiliations = scopedAffiliations;
+    }
 }

--- a/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
+++ b/pass-authz-core/src/main/java/org/dataconservancy/pass/authz/ShibAuthUserProvider.java
@@ -196,6 +196,12 @@ public class ShibAuthUserProvider implements AuthUserProvider {
                                 .map(sa -> sa.split("@")[1])
                                 .collect(toSet()));
 
+        authUser.setScopedAffiliations(stream(
+                                            ofNullable(
+                                                    getShibAttr(request, SCOPED_AFFILIATION_HEADER, s -> s.split(";")))
+                                                    .orElse(new String[0]))
+                                            .collect(toSet()));
+
         if (cacheLookupId != null) {
             LOG.debug("Looking up User based on hopkins id '{}'", cacheLookupId);
             try {

--- a/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
+++ b/pass-user-service/src/main/java/org/dataconservancy/pass/authz/service/user/UserServlet.java
@@ -24,6 +24,8 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -175,6 +177,7 @@ public class UserServlet extends HttpServlet {
         user.setLastName(authUser.getSurname());
         user.setEmail(authUser.getEmail());
         user.getRoles().add(User.Role.SUBMITTER);
+        user.setAffiliation(authUser.getScopedAffiliations());
 
         authUser.setUser(fedoraClient.createAndReadResource(user, User.class));
         authUser.setId(authUser.getUser().getId());
@@ -224,6 +227,11 @@ public class UserServlet extends HttpServlet {
         if (user.getLocatorIds() == null || !user.getLocatorIds().containsAll(shibUser.getLocatorIds())) {
             user.getLocatorIds().addAll(shibUser.getLocatorIds());
             user.setLocatorIds(new ArrayList<>(new HashSet(user.getLocatorIds())));//remove duplicates
+            update = true;
+        }
+
+        if (user.getAffiliation() == null || !user.getAffiliation().equals(shibUser.getScopedAffiliations())) {
+            user.setAffiliation(shibUser.getScopedAffiliations());
             update = true;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.23.0</mockito.version>
     <okhttp.version>3.11.0</okhttp.version>
-    <pass.fedora.client.version>0.6.0</pass.fedora.client.version>
+    <pass.fedora.client.version>0.7.0-SNAPSHOT</pass.fedora.client.version>
     <elasticsearch.version>6.2.4</elasticsearch.version>
     <slf4j.version>1.7.25</slf4j.version>
     <apache.log.api>2.11.1</apache.log.api>


### PR DESCRIPTION
Unmarshal the scoped affilations of principal from Shibboleth attributes,  and store them as User.affiliation.  Update to version 0.7.0-SNAPSHOT of the model and java client.

**TODO**: update this PR with a release version of the Java client before merging.

*N.B.* Travis won't pass until https://github.com/OA-PASS/java-fedora-client/pull/95 is merged
